### PR TITLE
feat: unify query path to .search-hub/queries/

### DIFF
--- a/spec/architecture.md
+++ b/spec/architecture.md
@@ -103,27 +103,28 @@ Commands that accept a query file (`search`, `query validate`, `query translate`
 
 1. Exact path exists → use it
 2. `<arg>.yaml` exists → use it
-3. `queries/<arg>.yaml` exists → use it
+3. `.search-hub/queries/<arg>.yaml` exists → use it
 4. Error with tried paths listed
 
 ### Project Directory Layout
 
 ```
 my-research-project/
-├── search-hub.config.toml      # Local config
-├── queries/                    # Query files (created by query init)
-│   ├── wba-pain.yaml
-│   ├── wba-intervention.yaml
-│   ├── wba-pain.search-log.yaml  # Auto-generated iteration log
-│   └── query.schema.json      # Shared JSON Schema for editor support
-└── sessions/                   # Search results (managed by search-hub)
-    ├── 20260306_wba-pain_a1b2c3/
-    │   ├── session.yaml
-    │   ├── query_common.yaml
-    │   ├── pubmed_query.txt
-    │   ├── pubmed_results.jsonl
-    │   └── pubmed_results.yaml
-    └── ...
+└── .search-hub/                  # Project directory (created by search-hub init)
+    ├── config.toml               # Local config
+    ├── queries/                  # Query files (created by query init)
+    │   ├── wba-pain.yaml
+    │   ├── wba-intervention.yaml
+    │   ├── wba-pain.search-log.yaml  # Auto-generated iteration log
+    │   └── query.schema.json    # Shared JSON Schema for editor support
+    └── sessions/                 # Search results (managed by search-hub)
+        ├── 20260306_wba-pain_a1b2c3/
+        │   ├── session.yaml
+        │   ├── query_common.yaml
+        │   ├── pubmed_query.txt
+        │   ├── pubmed_results.jsonl
+        │   └── pubmed_results.yaml
+        └── ...
 ```
 
 ### Search Flow

--- a/spec/cli/commands.md
+++ b/spec/cli/commands.md
@@ -65,7 +65,7 @@ search-hub search --db <provider> --query <query-string> [options]
 ### Examples
 
 ```bash
-# Search all enabled databases (query name resolves to queries/diabetes-ai.yaml)
+# Search all enabled databases (query name resolves to .search-hub/queries/diabetes-ai.yaml)
 search-hub search diabetes-ai
 
 # Explicit path also works
@@ -530,7 +530,7 @@ search-hub init [options]
 1. Creates config file in platform-specific config directory (see spec/models/config.md)
 2. Prompts for API keys interactively
 3. Creates session directory in platform-specific data directory
-4. Creates `queries/` directory in current working directory for query files
+4. Creates `.search-hub/queries/` directory for query files
 
 ---
 
@@ -545,13 +545,13 @@ When the argument does not point to an existing file, the following paths are tr
 
 1. Exact path as given
 2. `<arg>.yaml` in CWD
-3. `queries/<arg>.yaml` in CWD
+3. `.search-hub/queries/<arg>.yaml` in CWD
 
 This allows shorthand usage:
 
 ```bash
-# All equivalent (if queries/wba-pain.yaml exists)
-search-hub query validate queries/wba-pain.yaml
+# All equivalent (if .search-hub/queries/wba-pain.yaml exists)
+search-hub query validate .search-hub/queries/wba-pain.yaml
 search-hub query validate wba-pain.yaml
 search-hub query validate wba-pain
 ```
@@ -582,7 +582,7 @@ search-hub query init <title> [options]
 
 1. Sanitizes `<title>` to a filename: lowercase, spaces to hyphens, non-alphanumeric removed
 2. Generates a YAML template with `name: <title>` and `$schema` link
-3. Default output: `queries/<sanitized-title>.yaml` (creates `queries/` if needed)
+3. Default output: `.search-hub/queries/<sanitized-title>.yaml` (creates `.search-hub/queries/` if needed)
 4. Generates `query.schema.json` alongside the output file
 5. If `--stdout`, prints template to stdout without creating files
 6. If `-o`, writes to that path instead of default
@@ -590,10 +590,10 @@ search-hub query init <title> [options]
 #### Output Message
 
 ```
-Created: queries/wba-pain.yaml
+Created: .search-hub/queries/wba-pain.yaml
 
 Next steps:
-  1. Edit query:      $EDITOR queries/wba-pain.yaml
+  1. Edit query:      $EDITOR .search-hub/queries/wba-pain.yaml
   2. Validate:        search-hub query validate wba-pain
   3. Check counts:    search-hub search wba-pain --count-only
 
@@ -679,7 +679,7 @@ For `{path}/{name}.yaml`, the log file is `{path}/{name}.search-log.yaml`.
 
 Examples:
 - `./my-search.yaml` → `./my-search.search-log.yaml`
-- `./queries/diabetes.yaml` → `./queries/diabetes.search-log.yaml`
+- `./.search-hub/queries/diabetes.yaml` → `./.search-hub/queries/diabetes.search-log.yaml`
 
 #### Log File Format
 
@@ -725,7 +725,7 @@ The `query_hash` field links each count/preview entry to the specific version of
 ### Examples
 
 ```bash
-# Create a query file (writes to queries/diabetes-ai.yaml)
+# Create a query file (writes to .search-hub/queries/diabetes-ai.yaml)
 search-hub query init "diabetes ai"
 
 # Create with explicit output path
@@ -737,7 +737,7 @@ search-hub query init "diabetes ai" --stdout
 # Overwrite existing file
 search-hub query init "diabetes ai" --force
 
-# Validate query file (smart resolution: name → queries/<name>.yaml)
+# Validate query file (smart resolution: name → .search-hub/queries/<name>.yaml)
 search-hub query validate diabetes-ai
 
 # Show all translations
@@ -746,7 +746,7 @@ search-hub query translate diabetes-ai
 # Show PubMed translation only
 search-hub query translate diabetes-ai --db pubmed
 
-# Check hit counts (auto-logged to queries/diabetes-ai.search-log.yaml)
+# Check hit counts (auto-logged to .search-hub/queries/diabetes-ai.search-log.yaml)
 search-hub search diabetes-ai --count-only
 
 # Record assessment after reviewing counts

--- a/spec/tasks/20260309-01-query-path-to-project-dir.md
+++ b/spec/tasks/20260309-01-query-path-to-project-dir.md
@@ -33,76 +33,76 @@
 
 `paths.ts` の関数名を変更し、export を更新する。呼び出し元（`init.ts` の `initLocal`）も追従。
 
-- [ ] Write test: `src/config/paths.test.ts`
+- [x] Write test: `src/config/paths.test.ts`
   - `getQueriesDir()` が `.search-hub/queries/` を返すことを確認
   - `getQueriesDir(baseDir)` がカスタムベースで動作することを確認
-- [ ] Rename: `src/config/paths.ts` の `getLocalQueriesDir` → `getQueriesDir`
-- [ ] Update: `src/config/index.ts` の re-export
-- [ ] Update: `src/cli/commands/init.ts` の呼び出し箇所
-- [ ] Verify test passes (Green)
-- [ ] Run `npm run lint && npm run typecheck`
-- [ ] Acceptance: `getQueriesDir` が正しいパスを返し、既存の `init` コマンドが動作する
+- [x] Rename: `src/config/paths.ts` の `getLocalQueriesDir` → `getQueriesDir`
+- [x] Update: `src/config/index.ts` の re-export
+- [x] Update: `src/cli/commands/init.ts` の呼び出し箇所
+- [x] Verify test passes (Green)
+- [x] Run `npm run lint && npm run typecheck`
+- [x] Acceptance: `getQueriesDir` が正しいパスを返し、既存の `init` コマンドが動作する
 
 ### Step 2: `query init` を `.search-hub/queries/` に変更
 
 `QUERIES_DIR` 定数を廃止し、`getQueriesDir()` を使用する。
 
-- [ ] Write test: `src/cli/commands/query/init.test.ts`
+- [x] Write test: `src/cli/commands/query/init.test.ts`
   - デフォルト出力先が `.search-hub/queries/<sanitized>.yaml` になることを確認
   - `query.schema.json` が `.search-hub/queries/` 内に作成されることを確認
   - `-o` オプション指定時は従来通り指定パスに出力されることを確認
-- [ ] Implement: `src/cli/commands/query/init.ts`
+- [x] Implement: `src/cli/commands/query/init.ts`
   - `QUERIES_DIR` 定数を削除
   - `writeQueryTemplate` で `getQueriesDir(options.cwd)` を使用
-- [ ] Verify test fails (Red) → Implement → Verify test passes (Green)
-- [ ] Run `npm run lint && npm run typecheck`
-- [ ] Acceptance: `query init "title"` が `.search-hub/queries/title.yaml` を作成する
+- [x] Verify test fails (Red) → Implement → Verify test passes (Green)
+- [x] Run `npm run lint && npm run typecheck`
+- [x] Acceptance: `query init "title"` が `.search-hub/queries/title.yaml` を作成する
 
 ### Step 3: `resolveQueryFile` を `.search-hub/queries/` に変更
 
 ハードコードの `queries/` パスを `getQueriesDir()` 相対に変更。
 
-- [ ] Write test: `src/cli/commands/query/resolve.test.ts`
+- [x] Write test: `src/cli/commands/query/resolve.test.ts`
   - `.search-hub/queries/<arg>.yaml` が解決されることを確認
   - `.search-hub/queries/<arg>.yml` が解決されることを確認
   - エラーメッセージに `.search-hub/queries/` パスが含まれることを確認
-- [ ] Implement: `src/cli/commands/query/resolve.ts`
+- [x] Implement: `src/cli/commands/query/resolve.ts`
   - `queries/` → `getQueriesDir()` からの相対パスに変更
-- [ ] Verify test fails (Red) → Implement → Verify test passes (Green)
-- [ ] Run `npm run lint && npm run typecheck`
-- [ ] Acceptance: `resolveQueryFile("name")` が `.search-hub/queries/name.yaml` を探す
+- [x] Verify test fails (Red) → Implement → Verify test passes (Green)
+- [x] Run `npm run lint && npm run typecheck`
+- [x] Acceptance: `resolveQueryFile("name")` が `.search-hub/queries/name.yaml` を探す
 
 ### Step 4: サジェスト・ヘルプテキスト更新
 
-- [ ] Update: `src/cli/suggestions/rules.ts` — `queryInitRule` のデフォルトパス
-- [ ] Update: `src/cli/suggestions/rules.test.ts` — 期待値の更新
-- [ ] Update: `src/cli/index.ts` — `query init` のヘルプテキスト例
-- [ ] Run `npm run lint && npm run typecheck`
-- [ ] Acceptance: サジェスションとヘルプが `.search-hub/queries/` パスを表示する
+- [x] Update: `src/cli/suggestions/rules.ts` — `queryInitRule` のデフォルトパス
+- [x] Update: `src/cli/suggestions/rules.test.ts` — 期待値の更新
+- [x] Update: `src/cli/index.ts` — `query init` のヘルプテキスト例
+- [x] Run `npm run lint && npm run typecheck`
+- [x] Acceptance: サジェスションとヘルプが `.search-hub/queries/` パスを表示する
 
 ### Step 5: ドキュメント更新
 
-- [ ] Update: `spec/cli/commands.md`
+- [x] Update: `spec/cli/commands.md`
   - query init のデフォルト出力先の記述
   - query resolve の検索パスの記述
   - 使用例のパス
-- [ ] Update: `spec/architecture.md`
+- [x] Update: `spec/architecture.md`
   - プロジェクトディレクトリ構造の `queries/` → `.search-hub/queries/`
   - resolve の検索パス説明
-- [ ] Update: `spec/models/config.md`
+- [x] Update: `spec/models/config.md`
   - ディレクトリ構造の確認（既に `.search-hub/queries/` になっているはず）
-- [ ] Acceptance: ドキュメントがソースコードと整合している
+- [x] Acceptance: ドキュメントがソースコードと整合している
 
 ### Final Step: E2E Integration Tests (MANDATORY)
 
-- [ ] Update E2E test: `src/cli/commands/query/init.e2e.test.ts`
+- [x] Update E2E test: `src/cli/commands/query/init.e2e.test.ts`
   - `query init` が `.search-hub/queries/` にファイルを作成するフロー
-- [ ] Update E2E test: `src/cli/commands/query/resolve.e2e.test.ts`
+- [x] Update E2E test: `src/cli/commands/query/resolve.e2e.test.ts`
   - `.search-hub/queries/` 内のファイルが解決されるフロー
-- [ ] Verify all E2E tests pass
-- [ ] Run full test suite: `npm test`
-- [ ] **Manual verification**: `search-hub init` → `query init "test"` → `query validate test` のフルフロー
-- [ ] Acceptance: All tests pass, feature works in real usage
+- [x] Verify all E2E tests pass
+- [x] Run full test suite: `npm test`
+- [x] **Manual verification**: `search-hub init` → `query init "test"` → `query validate test` のフルフロー
+- [x] Acceptance: All tests pass, feature works in real usage
 
 ## Notes
 

--- a/src/cli/commands/query/init.e2e.test.ts
+++ b/src/cli/commands/query/init.e2e.test.ts
@@ -58,26 +58,26 @@ describe('search-hub query init E2E', () => {
     });
   });
 
-  describe('query init "<title>" creates file in queries/', () => {
-    it('should create queries/test-search.yaml', async () => {
+  describe('query init "<title>" creates file in .search-hub/queries/', () => {
+    it('should create .search-hub/queries/test-search.yaml', async () => {
       const result = await writeQueryTemplate({ title: 'test search', cwd: ctx.tempDir });
       expect(result.success).toBe(true);
-      const outputPath = join(ctx.tempDir, 'queries', 'test-search.yaml');
+      const outputPath = join(ctx.tempDir, '.search-hub', 'queries', 'test-search.yaml');
       const content = await readFile(outputPath, 'utf-8');
       expect(content).toContain('name: "test search"');
     });
 
     it('should set YAML name field to title', async () => {
       await writeQueryTemplate({ title: 'test search', cwd: ctx.tempDir });
-      const outputPath = join(ctx.tempDir, 'queries', 'test-search.yaml');
+      const outputPath = join(ctx.tempDir, '.search-hub', 'queries', 'test-search.yaml');
       const content = await readFile(outputPath, 'utf-8');
       const ast = parseQueryString(content);
       expect(ast.name).toBe('test search');
     });
 
-    it('should create query.schema.json in queries/', async () => {
+    it('should create query.schema.json in .search-hub/queries/', async () => {
       await writeQueryTemplate({ title: 'test search', cwd: ctx.tempDir });
-      const schemaPath = join(ctx.tempDir, 'queries', 'query.schema.json');
+      const schemaPath = join(ctx.tempDir, '.search-hub', 'queries', 'query.schema.json');
       await expect(access(schemaPath)).resolves.toBeUndefined();
       const schemaContent = await readFile(schemaPath, 'utf-8');
       const schema = JSON.parse(schemaContent);
@@ -86,7 +86,7 @@ describe('search-hub query init E2E', () => {
 
     it('should produce a file that passes validateQueryCommand', async () => {
       await writeQueryTemplate({ title: 'test search', cwd: ctx.tempDir });
-      const outputPath = join(ctx.tempDir, 'queries', 'test-search.yaml');
+      const outputPath = join(ctx.tempDir, '.search-hub', 'queries', 'test-search.yaml');
       const result = await validateQueryCommand(outputPath);
       expect(result.success).toBe(true);
       expect(result.queryName).toBe('test search');
@@ -103,7 +103,7 @@ describe('search-hub query init E2E', () => {
 
     it('should not create any files', async () => {
       await writeQueryTemplate({ title: 'WBA pain', stdout: true, cwd: ctx.tempDir });
-      await expect(stat(join(ctx.tempDir, 'queries'))).rejects.toThrow();
+      await expect(stat(join(ctx.tempDir, '.search-hub', 'queries'))).rejects.toThrow();
     });
   });
 
@@ -150,7 +150,7 @@ describe('search-hub query init E2E', () => {
 
     it('should generate template that passes validateQueryCommand with $schema comment', async () => {
       await writeQueryTemplate({ title: 'test', cwd: ctx.tempDir });
-      const outputPath = join(ctx.tempDir, 'queries', 'test.yaml');
+      const outputPath = join(ctx.tempDir, '.search-hub', 'queries', 'test.yaml');
       const result = await validateQueryCommand(outputPath);
       expect(result.success).toBe(true);
       expect(result.queryName).toBe('test');

--- a/src/cli/commands/query/init.test.ts
+++ b/src/cli/commands/query/init.test.ts
@@ -107,41 +107,41 @@ describe('query init', () => {
   });
 
   describe('writeQueryTemplate', () => {
-    it('should write to queries/<sanitized-title>.yaml by default', async () => {
+    it('should write to .search-hub/queries/<sanitized-title>.yaml by default', async () => {
       const result = await writeQueryTemplate({ title: 'WBA pain', cwd: tempDir });
       expect(result.success).toBe(true);
-      const content = await readFile(join(tempDir, 'queries', 'wba-pain.yaml'), 'utf-8');
+      const content = await readFile(join(tempDir, '.search-hub', 'queries', 'wba-pain.yaml'), 'utf-8');
       expect(content).toContain('name: "WBA pain"');
     });
 
-    it('should auto-create queries/ directory', async () => {
+    it('should auto-create .search-hub/queries/ directory', async () => {
       await writeQueryTemplate({ title: 'test search', cwd: tempDir });
-      const stats = await stat(join(tempDir, 'queries'));
+      const stats = await stat(join(tempDir, '.search-hub', 'queries'));
       expect(stats.isDirectory()).toBe(true);
     });
 
-    it('should create query.schema.json in queries/', async () => {
+    it('should create query.schema.json in .search-hub/queries/', async () => {
       await writeQueryTemplate({ title: 'test search', cwd: tempDir });
-      const schemaPath = join(tempDir, 'queries', 'query.schema.json');
+      const schemaPath = join(tempDir, '.search-hub', 'queries', 'query.schema.json');
       const schemaContent = await readFile(schemaPath, 'utf-8');
       const schema = JSON.parse(schemaContent);
       expect(schema.$schema).toContain('json-schema.org');
     });
 
     it('should refuse to overwrite existing file without --force', async () => {
-      await mkdir(join(tempDir, 'queries'), { recursive: true });
-      await writeFile(join(tempDir, 'queries', 'test.yaml'), 'existing', 'utf-8');
+      await mkdir(join(tempDir, '.search-hub', 'queries'), { recursive: true });
+      await writeFile(join(tempDir, '.search-hub', 'queries', 'test.yaml'), 'existing', 'utf-8');
       const result = await writeQueryTemplate({ title: 'test', cwd: tempDir });
       expect(result.success).toBe(false);
       expect(result.message).toContain('exists');
     });
 
     it('should overwrite existing file with --force', async () => {
-      await mkdir(join(tempDir, 'queries'), { recursive: true });
-      await writeFile(join(tempDir, 'queries', 'test.yaml'), 'existing', 'utf-8');
+      await mkdir(join(tempDir, '.search-hub', 'queries'), { recursive: true });
+      await writeFile(join(tempDir, '.search-hub', 'queries', 'test.yaml'), 'existing', 'utf-8');
       const result = await writeQueryTemplate({ title: 'test', cwd: tempDir, force: true });
       expect(result.success).toBe(true);
-      const content = await readFile(join(tempDir, 'queries', 'test.yaml'), 'utf-8');
+      const content = await readFile(join(tempDir, '.search-hub', 'queries', 'test.yaml'), 'utf-8');
       expect(content).toContain('name: "test"');
     });
 
@@ -161,8 +161,8 @@ describe('query init', () => {
 
     it('should not create files when --stdout is used', async () => {
       await writeQueryTemplate({ title: 'my search', stdout: true, cwd: tempDir });
-      // queries/ directory should NOT be created
-      await expect(stat(join(tempDir, 'queries'))).rejects.toThrow();
+      // .search-hub/queries/ directory should NOT be created
+      await expect(stat(join(tempDir, '.search-hub', 'queries'))).rejects.toThrow();
     });
 
     it('should include $schema comment in stdout output', async () => {

--- a/src/cli/commands/query/init.ts
+++ b/src/cli/commands/query/init.ts
@@ -6,6 +6,7 @@
 import { writeFile as fsWriteFile, access, mkdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { generateQueryJSONSchema } from "../../../query/json-schema.js";
+import { getQueriesDir } from "../../../config/paths.js";
 
 /**
  * Sanitize a title string into a safe filename (without extension).
@@ -99,7 +100,6 @@ export function generateQueryTemplate(title?: string): string {
   return QUERY_TEMPLATE.replace('name: my_search', `name: "${escaped}"`);
 }
 
-export const QUERIES_DIR = "queries";
 
 export interface WriteQueryTemplateOptions {
   title: string;
@@ -126,7 +126,7 @@ export async function writeQueryTemplate(options: WriteQueryTemplateOptions): Pr
 
   // Determine output path
   const outputPath = options.output
-    ?? join(options.cwd ?? process.cwd(), QUERIES_DIR, `${sanitizeForFilename(options.title)}.yaml`);
+    ?? join(getQueriesDir(options.cwd), `${sanitizeForFilename(options.title)}.yaml`);
 
   // Check if file exists (unless force is set)
   if (!options.force) {

--- a/src/cli/commands/query/resolve.e2e.test.ts
+++ b/src/cli/commands/query/resolve.e2e.test.ts
@@ -44,18 +44,18 @@ describe('smart query file resolution E2E', () => {
       expect(resolved).toBe('my-query.yaml');
     });
 
-    it('resolves queries/<name>.yaml', async () => {
-      await mkdir(join(ctx.tempDir, 'queries'), { recursive: true });
-      await createRawQueryFile(join(ctx.tempDir, 'queries'), 'name: test\nquery:\n  - id: b1\n    field: title\n    terms:\n      keywords:\n        - test\n    operator: OR\n', 'wba-pain.yaml');
+    it('resolves .search-hub/queries/<name>.yaml', async () => {
+      await mkdir(join(ctx.tempDir, '.search-hub', 'queries'), { recursive: true });
+      await createRawQueryFile(join(ctx.tempDir, '.search-hub', 'queries'), 'name: test\nquery:\n  - id: b1\n    field: title\n    terms:\n      keywords:\n        - test\n    operator: OR\n', 'wba-pain.yaml');
       const resolved = await resolveQueryFile('wba-pain');
-      expect(resolved).toBe('queries/wba-pain.yaml');
+      expect(resolved).toBe('.search-hub/queries/wba-pain.yaml');
     });
 
-    it('resolves queries/<name>.yml when .yaml does not exist', async () => {
-      await mkdir(join(ctx.tempDir, 'queries'), { recursive: true });
-      await createRawQueryFile(join(ctx.tempDir, 'queries'), 'name: test\nquery:\n  - id: b1\n    field: title\n    terms:\n      keywords:\n        - test\n    operator: OR\n', 'wba-pain.yml');
+    it('resolves .search-hub/queries/<name>.yml when .yaml does not exist', async () => {
+      await mkdir(join(ctx.tempDir, '.search-hub', 'queries'), { recursive: true });
+      await createRawQueryFile(join(ctx.tempDir, '.search-hub', 'queries'), 'name: test\nquery:\n  - id: b1\n    field: title\n    terms:\n      keywords:\n        - test\n    operator: OR\n', 'wba-pain.yml');
       const resolved = await resolveQueryFile('wba-pain');
-      expect(resolved).toBe('queries/wba-pain.yml');
+      expect(resolved).toBe('.search-hub/queries/wba-pain.yml');
     });
 
     it('throws with helpful error for missing query', async () => {
@@ -72,7 +72,7 @@ describe('smart query file resolution E2E', () => {
 
       // Resolve the short name
       const resolved = await resolveQueryFile('test-query');
-      expect(resolved).toBe('queries/test-query.yaml');
+      expect(resolved).toBe('.search-hub/queries/test-query.yaml');
 
       // Validate using the resolved path
       const validateResult = await validateQueryCommand(resolved);
@@ -84,7 +84,7 @@ describe('smart query file resolution E2E', () => {
       await writeQueryTemplate({ title: 'test ext', cwd: ctx.tempDir });
 
       const resolved = await resolveQueryFile('test-ext.yaml');
-      expect(resolved).toBe('queries/test-ext.yaml');
+      expect(resolved).toBe('.search-hub/queries/test-ext.yaml');
 
       const validateResult = await validateQueryCommand(resolved);
       expect(validateResult.success).toBe(true);

--- a/src/cli/commands/query/resolve.test.ts
+++ b/src/cli/commands/query/resolve.test.ts
@@ -38,7 +38,7 @@ describe('resolveQueryFile', () => {
     // queries/arg.yaml exists
     mockedFs.stat.mockResolvedValueOnce({ isFile: () => true } as any);
     const result = await resolveQueryFile('my-query');
-    expect(result).toBe('queries/my-query.yaml');
+    expect(result).toBe('.search-hub/queries/my-query.yaml');
   });
 
   it('prefers exact path over .yaml suffix', async () => {
@@ -60,7 +60,7 @@ describe('resolveQueryFile', () => {
       './wba-pain.yaml'
     );
     await expect(resolveQueryFile('wba-pain')).rejects.toThrow(
-      './queries/wba-pain.yaml'
+      '.search-hub/queries/wba-pain.yaml'
     );
     await expect(resolveQueryFile('wba-pain')).rejects.toThrow(
       'query init'
@@ -89,7 +89,7 @@ describe('resolveQueryFile', () => {
     // queries/arg.yml exists
     mockedFs.stat.mockResolvedValueOnce({ isFile: () => true } as any);
     const result = await resolveQueryFile('my-query');
-    expect(result).toBe('queries/my-query.yml');
+    expect(result).toBe('.search-hub/queries/my-query.yml');
   });
 
   it('skips .yaml step when arg already ends with .yaml', async () => {
@@ -98,6 +98,6 @@ describe('resolveQueryFile', () => {
     // queries/my-query.yaml exists (skips arg+.yaml since it already has .yaml)
     mockedFs.stat.mockResolvedValueOnce({ isFile: () => true } as any);
     const result = await resolveQueryFile('my-query.yaml');
-    expect(result).toBe('queries/my-query.yaml');
+    expect(result).toBe('.search-hub/queries/my-query.yaml');
   });
 });

--- a/src/cli/commands/query/resolve.ts
+++ b/src/cli/commands/query/resolve.ts
@@ -4,11 +4,13 @@
  * Resolution order:
  * 1. Exact path exists → use it
  * 2. <arg>.yaml exists → use it
- * 3. queries/<arg>.yaml exists → use it
- * 4. queries/<arg>.yml exists → use it
+ * 3. .search-hub/queries/<arg>.yaml exists → use it
+ * 4. .search-hub/queries/<arg>.yml exists → use it
  * 5. Error with tried paths
  */
 import { stat } from 'node:fs/promises';
+import { relative } from 'node:path';
+import { getQueriesDir } from '../../../config/paths.js';
 
 export class NotAFileError extends Error {
   constructor(path: string) {
@@ -50,8 +52,9 @@ export async function resolveQueryFile(arg: string): Promise<string> {
   }
 
   // 3. .search-hub/queries/<arg>.yaml
+  const queriesDir = relative(process.cwd(), getQueriesDir());
   const basename = arg.endsWith('.yaml') || arg.endsWith('.yml') ? arg : `${arg}.yaml`;
-  const inQueries = `.search-hub/queries/${basename}`;
+  const inQueries = `${queriesDir}/${basename}`;
   candidates.push(inQueries);
   if (await isFile(inQueries)) {
     return inQueries;
@@ -59,7 +62,7 @@ export async function resolveQueryFile(arg: string): Promise<string> {
 
   // 4. .search-hub/queries/<arg>.yml (skip if arg already has extension)
   if (!arg.endsWith('.yaml') && !arg.endsWith('.yml')) {
-    const inQueriesYml = `.search-hub/queries/${arg}.yml`;
+    const inQueriesYml = `${queriesDir}/${arg}.yml`;
     candidates.push(inQueriesYml);
     if (await isFile(inQueriesYml)) {
       return inQueriesYml;

--- a/src/cli/commands/query/resolve.ts
+++ b/src/cli/commands/query/resolve.ts
@@ -49,17 +49,17 @@ export async function resolveQueryFile(arg: string): Promise<string> {
     }
   }
 
-  // 3. queries/<arg>.yaml
+  // 3. .search-hub/queries/<arg>.yaml
   const basename = arg.endsWith('.yaml') || arg.endsWith('.yml') ? arg : `${arg}.yaml`;
-  const inQueries = `queries/${basename}`;
+  const inQueries = `.search-hub/queries/${basename}`;
   candidates.push(inQueries);
   if (await isFile(inQueries)) {
     return inQueries;
   }
 
-  // 4. queries/<arg>.yml (skip if arg already has extension)
+  // 4. .search-hub/queries/<arg>.yml (skip if arg already has extension)
   if (!arg.endsWith('.yaml') && !arg.endsWith('.yml')) {
-    const inQueriesYml = `queries/${arg}.yml`;
+    const inQueriesYml = `.search-hub/queries/${arg}.yml`;
     candidates.push(inQueriesYml);
     if (await isFile(inQueriesYml)) {
       return inQueriesYml;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -790,7 +790,7 @@ Examples:
     .option('--force', 'overwrite existing file', false)
     .addHelpText('after', `
 Examples:
-  $ search-hub query init "WBA pain mechanisms"              # → queries/wba-pain-mechanisms.yaml
+  $ search-hub query init "WBA pain mechanisms"              # → .search-hub/queries/wba-pain-mechanisms.yaml
   $ search-hub query init "WBA pain" -o ./custom-path.yaml   # Custom output path
   $ search-hub query init "WBA pain" --stdout                # Print to stdout`)
     .action(async (title: string, options: { output?: string; stdout?: boolean; force?: boolean }) => {

--- a/src/cli/suggestions/rules.ts
+++ b/src/cli/suggestions/rules.ts
@@ -5,7 +5,7 @@ import { computeBatchContinuation, generateReviewNextSteps } from '../commands/r
 
 const queryInitRule: SuggestionRule = (ctx) => {
   if (ctx.command !== 'query init') return null;
-  const file = ctx.outputFile ?? 'queries/query.yaml';
+  const file = ctx.outputFile ?? '.search-hub/queries/query.yaml';
   return {
     next: [
       { command: `$EDITOR ${file}`, description: 'Edit your query' },

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -11,6 +11,6 @@ export {
   getProjectDir,
   getLocalConfigPath,
   getLocalSessionsDir,
-  getLocalQueriesDir,
+  getQueriesDir,
   isInsideProject,
 } from './paths';

--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -10,7 +10,7 @@ import {
   getProjectDir,
   getLocalConfigPath,
   getLocalSessionsDir,
-  getLocalQueriesDir,
+  getQueriesDir,
   isInsideProject,
 } from './paths.js';
 
@@ -93,10 +93,15 @@ describe('paths', () => {
     });
   });
 
-  describe('getLocalQueriesDir', () => {
+  describe('getQueriesDir', () => {
     it('returns .search-hub/queries relative to given directory', () => {
-      const result = getLocalQueriesDir('/some/project');
+      const result = getQueriesDir('/some/project');
       expect(result).toBe(join('/some/project', '.search-hub', 'queries'));
+    });
+
+    it('defaults to cwd when no directory specified', () => {
+      const result = getQueriesDir();
+      expect(result).toBe(join(process.cwd(), '.search-hub', 'queries'));
     });
   });
 

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -71,7 +71,7 @@ export function getLocalSessionsDir(baseDir?: string): string {
 /**
  * Get the local queries directory (.search-hub/queries/).
  */
-export function getLocalQueriesDir(baseDir?: string): string {
+export function getQueriesDir(baseDir?: string): string {
   return join(getProjectDir(baseDir), 'queries');
 }
 


### PR DESCRIPTION
## Summary

- Rename `getLocalQueriesDir` → `getQueriesDir` in `src/config/paths.ts` for consistency
- Change `query init` default output from `queries/` to `.search-hub/queries/` using `getQueriesDir()`
- Change `resolveQueryFile` to search `.search-hub/queries/` instead of `queries/`
- Update suggestion default path and CLI help text
- Update spec docs (commands.md, architecture.md) to reflect new paths

Fixes #134

## Test plan

- [x] Unit tests for `getQueriesDir()` (paths.test.ts)
- [x] Unit tests for `writeQueryTemplate` with `.search-hub/queries/` output (init.test.ts)
- [x] Unit tests for `resolveQueryFile` with `.search-hub/queries/` paths (resolve.test.ts)
- [x] E2E tests for query init flow (init.e2e.test.ts)
- [x] E2E tests for query resolve flow (resolve.e2e.test.ts)
- [x] Full test suite: 149 files passed, 2964 tests passed
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)