### PR TITLE
fix: prevent unrelated PMC IDs from being attached during fulltext check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
-        "@ncukondo/academic-fulltext": "^0.2.0",
+        "@ncukondo/academic-fulltext": "^0.2.6",
         "cli-progress": "^3.12.0",
         "commander": "^13.0.0",
         "dotenv": "^17.2.3",
@@ -639,9 +639,9 @@
       }
     },
     "node_modules/@ncukondo/academic-fulltext": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ncukondo/academic-fulltext/-/academic-fulltext-0.2.0.tgz",
-      "integrity": "sha512-60IQWtws7ecnQ1wnW27VJFZSTTKy1eGQvLVo6Vkzf5jk+0QlpxrBEB+KKVUNpiewwguhnEC75lDqRcHkSTXaiQ==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@ncukondo/academic-fulltext/-/academic-fulltext-0.2.6.tgz",
+      "integrity": "sha512-7Ce7mLL0fxHrR9ZCdKv+V1reH9fNn8ob9Jpg+UiSRu7r3v8nR/WmvVVB1Umwe9ZlAk8iaHQFhRRBTcm87dU+qQ==",
       "license": "MIT",
       "dependencies": {
         "any-ascii": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "license": "MIT",
   "dependencies": {
     "@iarna/toml": "^3.0.0",
-    "@ncukondo/academic-fulltext": "^0.2.0",
+    "@ncukondo/academic-fulltext": "^0.2.6",
     "cli-progress": "^3.12.0",
     "commander": "^13.0.0",
     "dotenv": "^17.2.3",

--- a/src/cli/commands/fulltext/check.test.ts
+++ b/src/cli/commands/fulltext/check.test.ts
@@ -16,6 +16,11 @@ const mockDiscoverOA = vi.mocked(academicFulltext.discoverOA);
 const mockLoadMeta = vi.mocked(academicFulltext.loadMeta);
 const mockSaveMeta = vi.mocked(academicFulltext.saveMeta);
 
+// Mock PMCID verification (network-backed)
+vi.mock('./verify-pmcid', () => ({ verifyPmcid: vi.fn() }));
+import { verifyPmcid } from './verify-pmcid';
+const mockVerifyPmcid = vi.mocked(verifyPmcid);
+
 // Mock fs operations
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
@@ -82,8 +87,9 @@ articles:
       throw new Error(`File not found: ${p}`);
     });
 
-    // Default: loadMeta returns sample meta
-    mockLoadMeta.mockResolvedValue(sampleMeta);
+    // Default: loadMeta returns a fresh copy of sample meta
+    // (check.ts mutates the loaded object before saving)
+    mockLoadMeta.mockImplementation(async () => ({ ...sampleMeta, files: {} }));
 
     // Default: fulltext directory with one entry
     mockReaddir.mockResolvedValue(
@@ -235,6 +241,119 @@ articles:
     expect(maxConcurrent).toBeLessThanOrEqual(2);
     // Verify concurrency was actually used (> 1 concurrent)
     expect(maxConcurrent).toBeGreaterThan(1);
+  });
+
+  describe('discovered PMCID verification', () => {
+    const pmcDiscoveryResult = {
+      oaStatus: 'open' as const,
+      locations: [
+        { source: 'pmc' as const, url: 'https://www.ncbi.nlm.nih.gov/pmc/articles/PMC12928693/pdf/', urlType: 'pdf' as const, version: 'published' as const },
+        { source: 'pmc' as const, url: 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pmc&id=12928693', urlType: 'xml' as const, version: 'published' as const },
+      ],
+      errors: [],
+      skipped: [],
+      checkedSources: ['pmc'],
+      discoveredIds: { pmcid: 'PMC12928693' },
+    };
+
+    it('drops PMC locations when the discovered PMCID does not match the article', async () => {
+      mockDiscoverOA.mockResolvedValue(pmcDiscoveryResult);
+      mockVerifyPmcid.mockResolvedValue('mismatch');
+
+      const result = await executeFulltextCheck({
+        sessionDir,
+        config: { unpaywallEmail: 'test@example.com', coreApiKey: '', preferSources: [] },
+      });
+
+      const article = result.articles.find((a) => a.pmid === '11111111');
+      expect(article?.rejectedPmcid).toBe('PMC12928693');
+      expect(article?.locationCount).toBe(0);
+      expect(article?.oaStatus).toBe('unknown');
+
+      // meta.json must not receive the unrelated PMC locations
+      const savedMeta = mockSaveMeta.mock.calls.find(
+        ([, meta]) => (meta as FulltextMeta).pmid === '11111111'
+      )?.[1] as FulltextMeta | undefined;
+      if (savedMeta) {
+        expect(savedMeta.oaLocations).toEqual([]);
+        expect(savedMeta.pmcid).toBeUndefined();
+      }
+    });
+
+    it('keeps non-PMC locations when the discovered PMCID mismatches', async () => {
+      mockDiscoverOA.mockResolvedValue({
+        ...pmcDiscoveryResult,
+        locations: [
+          ...pmcDiscoveryResult.locations,
+          { source: 'unpaywall' as const, url: 'https://example.com/paper.pdf', urlType: 'pdf' as const, version: 'published' as const },
+        ],
+      });
+      mockVerifyPmcid.mockResolvedValue('mismatch');
+
+      const result = await executeFulltextCheck({
+        sessionDir,
+        config: { unpaywallEmail: 'test@example.com', coreApiKey: '', preferSources: [] },
+      });
+
+      const article = result.articles.find((a) => a.pmid === '11111111');
+      expect(article?.locationCount).toBe(1);
+      expect(article?.oaStatus).toBe('open');
+    });
+
+    it('keeps PMC locations and records the PMCID when verification matches', async () => {
+      mockDiscoverOA.mockResolvedValue(pmcDiscoveryResult);
+      mockVerifyPmcid.mockResolvedValue('match');
+
+      const result = await executeFulltextCheck({
+        sessionDir,
+        config: { unpaywallEmail: 'test@example.com', coreApiKey: '', preferSources: [] },
+      });
+
+      const article = result.articles.find((a) => a.pmid === '11111111');
+      expect(article?.pmcid).toBe('PMC12928693');
+      expect(article?.rejectedPmcid).toBeUndefined();
+      expect(article?.locationCount).toBe(2);
+
+      // Verified PMCID is persisted to meta.json
+      const savedMeta = mockSaveMeta.mock.calls.find(
+        ([, meta]) => (meta as FulltextMeta).pmid === '11111111'
+      )?.[1] as FulltextMeta | undefined;
+      expect(savedMeta?.pmcid).toBe('PMC12928693');
+    });
+
+    it('keeps PMC locations but does not persist the PMCID when unverified', async () => {
+      mockDiscoverOA.mockResolvedValue(pmcDiscoveryResult);
+      mockVerifyPmcid.mockResolvedValue('unverified');
+
+      const result = await executeFulltextCheck({
+        sessionDir,
+        config: { unpaywallEmail: 'test@example.com', coreApiKey: '', preferSources: [] },
+      });
+
+      const article = result.articles.find((a) => a.pmid === '11111111');
+      expect(article?.pmcid).toBeUndefined();
+      expect(article?.rejectedPmcid).toBeUndefined();
+      expect(article?.locationCount).toBe(2);
+
+      const savedMeta = mockSaveMeta.mock.calls.find(
+        ([, meta]) => (meta as FulltextMeta).pmid === '11111111'
+      )?.[1] as FulltextMeta | undefined;
+      expect(savedMeta?.pmcid).toBeUndefined();
+    });
+
+    it('does not verify when no PMCID was discovered', async () => {
+      mockDiscoverOA.mockResolvedValue({
+        ...pmcDiscoveryResult,
+        discoveredIds: {},
+      });
+
+      await executeFulltextCheck({
+        sessionDir,
+        config: { unpaywallEmail: 'test@example.com', coreApiKey: '', preferSources: [] },
+      });
+
+      expect(mockVerifyPmcid).not.toHaveBeenCalled();
+    });
   });
 
   it('handles missing reviews.yaml', async () => {

--- a/src/cli/commands/fulltext/check.test.ts
+++ b/src/cli/commands/fulltext/check.test.ts
@@ -102,6 +102,8 @@ articles:
             { source: 'unpaywall' as const, url: 'https://example.com/paper.pdf', urlType: 'pdf' as const, version: 'published' as const },
           ],
           errors: [],
+          skipped: [],
+          checkedSources: [],
           discoveredIds: {},
         };
       }
@@ -109,6 +111,8 @@ articles:
         oaStatus: 'closed' as const,
         locations: [],
         errors: [],
+        skipped: [],
+        checkedSources: [],
         discoveredIds: {},
       };
     });
@@ -217,7 +221,7 @@ articles:
       // Simulate async work
       await new Promise((resolve) => setTimeout(resolve, 10));
       currentConcurrent--;
-      return { oaStatus: 'closed' as const, locations: [], errors: [], discoveredIds: {} };
+      return { oaStatus: 'closed' as const, locations: [], errors: [], skipped: [], checkedSources: [], discoveredIds: {} };
     });
 
     const result = await executeFulltextCheck({

--- a/src/cli/commands/fulltext/check.ts
+++ b/src/cli/commands/fulltext/check.ts
@@ -6,8 +6,9 @@
 import { readFile, readdir, access } from 'node:fs/promises';
 import { join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
-import { discoverOA, loadMeta, saveMeta, type DiscoveryConfig, type DiscoveryArticle, type OAStatus } from '@ncukondo/academic-fulltext';
+import { discoverOA, loadMeta, saveMeta, type DiscoveryConfig, type DiscoveryArticle, type OAStatus, type OALocation } from '@ncukondo/academic-fulltext';
 import type { ReviewFile, ArticleEntry } from '../review/types';
+import { verifyPmcid } from './verify-pmcid';
 
 /** Default concurrency for parallel article processing */
 const DEFAULT_CONCURRENCY = 3;
@@ -21,6 +22,10 @@ export interface FulltextCheckOptions {
 export interface FulltextCheckArticleResult {
   doi?: string;
   pmid?: string;
+  /** PMCID discovered during OA check and verified against the article */
+  pmcid?: string;
+  /** PMCID discovered during OA check but rejected because its metadata did not match */
+  rejectedPmcid?: string;
   title: string;
   oaStatus: OAStatus;
   locationCount: number;
@@ -83,6 +88,54 @@ async function findArticleDir(
   return null;
 }
 
+/** Outcome of validating a discovered PMCID against the article. */
+interface ValidatedDiscovery {
+  oaStatus: OAStatus;
+  locations: OALocation[];
+  verifiedPmcid?: string;
+  rejectedPmcid?: string;
+}
+
+/**
+ * Validate a PMCID discovered during OA discovery against the article's
+ * own metadata. On mismatch, drop all PMC locations so an unrelated
+ * paper's fulltext is never fetched (issue #146).
+ */
+async function validateDiscoveredPmcid(
+  article: ArticleEntry,
+  config: DiscoveryConfig,
+  discoveredPmcid: string | undefined,
+  oaStatus: OAStatus,
+  locations: OALocation[]
+): Promise<ValidatedDiscovery> {
+  const hasPmcLocations = locations.some((loc) => loc.source === 'pmc');
+  if (!discoveredPmcid || !hasPmcLocations) {
+    return { oaStatus, locations };
+  }
+
+  const verifyArticle: { doi?: string; pmid?: string; title?: string } = {
+    title: article.title,
+  };
+  if (article.doi) verifyArticle.doi = article.doi;
+  if (article.pmid) verifyArticle.pmid = article.pmid;
+  const verifyOptions: { ncbiEmail?: string; ncbiTool?: string } = {};
+  if (config.ncbiEmail) verifyOptions.ncbiEmail = config.ncbiEmail;
+  if (config.ncbiTool) verifyOptions.ncbiTool = config.ncbiTool;
+
+  const verification = await verifyPmcid(discoveredPmcid, verifyArticle, verifyOptions);
+
+  if (verification === 'match') {
+    return { oaStatus, locations, verifiedPmcid: discoveredPmcid };
+  }
+  if (verification === 'mismatch') {
+    const filtered = locations.filter((loc) => loc.source !== 'pmc');
+    const status = filtered.length === 0 && oaStatus === 'open' ? 'unknown' : oaStatus;
+    return { oaStatus: status, locations: filtered, rejectedPmcid: discoveredPmcid };
+  }
+  // Unverified: keep locations but do not vouch for the PMCID
+  return { oaStatus, locations };
+}
+
 /**
  * Process a single article: run OA discovery and optionally update meta.json.
  */
@@ -97,13 +150,23 @@ async function processArticle(
   if (article.arxivId) discoveryArticle.arxivId = article.arxivId;
   const discoveryResult = await discoverOA(discoveryArticle, config);
 
+  const validated = await validateDiscoveredPmcid(
+    article,
+    config,
+    discoveryResult.discoveredIds.pmcid,
+    discoveryResult.oaStatus,
+    discoveryResult.locations
+  );
+
   const articleResult: FulltextCheckArticleResult = {
     title: article.title,
-    oaStatus: discoveryResult.oaStatus,
-    locationCount: discoveryResult.locations.length,
+    oaStatus: validated.oaStatus,
+    locationCount: validated.locations.length,
   };
   if (article.doi) articleResult.doi = article.doi;
   if (article.pmid) articleResult.pmid = article.pmid;
+  if (validated.verifiedPmcid) articleResult.pmcid = validated.verifiedPmcid;
+  if (validated.rejectedPmcid) articleResult.rejectedPmcid = validated.rejectedPmcid;
 
   // Try to update meta.json if a fulltext directory exists for this article
   const dirName = await findArticleDir(sessionDir, article);
@@ -111,8 +174,11 @@ async function processArticle(
     try {
       const metaPath = join(sessionDir, 'fulltext', dirName, 'meta.json');
       const meta = await loadMeta(metaPath);
-      meta.oaStatus = discoveryResult.oaStatus;
-      meta.oaLocations = discoveryResult.locations;
+      meta.oaStatus = validated.oaStatus;
+      meta.oaLocations = validated.locations;
+      if (validated.verifiedPmcid && !meta.pmcid) {
+        meta.pmcid = validated.verifiedPmcid;
+      }
       meta.checkedAt = new Date().toISOString();
       await saveMeta(metaPath, meta);
     } catch {

--- a/src/cli/commands/fulltext/index.ts
+++ b/src/cli/commands/fulltext/index.ts
@@ -237,6 +237,15 @@ Examples:
           console.log(`  Closed Access:  ${result.summary.closed}`);
           console.log(`  Unknown:        ${result.summary.unknown}`);
           console.log(`  Total:          ${result.summary.total}`);
+          const rejected = result.articles.filter((a) => a.rejectedPmcid);
+          if (rejected.length > 0) {
+            console.log(`\nWarnings:`);
+            for (const article of rejected) {
+              console.log(
+                `  Discovered ${article.rejectedPmcid} does not match "${article.title}" — PMC locations dropped.`
+              );
+            }
+          }
           if (result.summary.open > 0) {
             console.log(`\nRun \`fulltext fetch\` to download available OA articles.`);
           }

--- a/src/cli/commands/fulltext/verify-pmcid.test.ts
+++ b/src/cli/commands/fulltext/verify-pmcid.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for PMCID verification against source article metadata.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { verifyPmcid } from './verify-pmcid';
+
+/** Build an esummary db=pmc JSON response for a single record. */
+function esummaryResponse(record: {
+  uid: string;
+  title?: string;
+  pmid?: string;
+  doi?: string;
+}): unknown {
+  const articleids: Array<{ idtype: string; value: string }> = [
+    { idtype: 'pmcid', value: `PMC${record.uid}` },
+  ];
+  if (record.pmid) articleids.push({ idtype: 'pmid', value: record.pmid });
+  if (record.doi) articleids.push({ idtype: 'doi', value: record.doi });
+  return {
+    header: { type: 'esummary', version: '0.3' },
+    result: {
+      uids: [record.uid],
+      [record.uid]: {
+        uid: record.uid,
+        title: record.title ?? '',
+        articleids,
+      },
+    },
+  };
+}
+
+function mockFetchJson(body: unknown): typeof fetch {
+  return vi.fn(async () =>
+    new Response(JSON.stringify(body), { status: 200 })
+  ) as unknown as typeof fetch;
+}
+
+describe('verifyPmcid', () => {
+  // The real-world case from issue #146: PMID 29538103 was linked to
+  // PMC12928693, which is a different paper.
+  it('returns mismatch when the PMC record belongs to a different article', async () => {
+    const fetchFn = mockFetchJson(
+      esummaryResponse({
+        uid: '12928693',
+        title:
+          'A Log-Level Data-Driven Precision Education Tool for Pediatrics Trainees: Human-Centered Development and Validation Study.',
+        pmid: '41730172',
+        doi: '10.2196/79952',
+      })
+    );
+
+    const result = await verifyPmcid(
+      'PMC12928693',
+      {
+        doi: '10.1097/ACM.0000000000002209',
+        pmid: '29538103',
+        title:
+          'Harnessing the Power of Big Data to Improve Graduate Medical Education: Big Idea or Bust?',
+      },
+      { fetchFn }
+    );
+
+    expect(result).toBe('mismatch');
+  });
+
+  it('returns match when DOI matches', async () => {
+    const fetchFn = mockFetchJson(
+      esummaryResponse({
+        uid: '123456',
+        title: 'Some Article',
+        pmid: '11111111',
+        doi: '10.1234/example',
+      })
+    );
+
+    const result = await verifyPmcid(
+      'PMC123456',
+      { doi: '10.1234/example', pmid: '11111111', title: 'Some Article' },
+      { fetchFn }
+    );
+
+    expect(result).toBe('match');
+  });
+
+  it('matches DOI case-insensitively and ignores url prefixes', async () => {
+    const fetchFn = mockFetchJson(
+      esummaryResponse({ uid: '123456', doi: '10.1097/acm.0000000000002209' })
+    );
+
+    const result = await verifyPmcid(
+      'PMC123456',
+      { doi: 'https://doi.org/10.1097/ACM.0000000000002209' },
+      { fetchFn }
+    );
+
+    expect(result).toBe('match');
+  });
+
+  it('falls back to PMID comparison when the PMC record has no DOI', async () => {
+    const fetchFn = mockFetchJson(
+      esummaryResponse({ uid: '123456', pmid: '29538103' })
+    );
+
+    const result = await verifyPmcid(
+      'PMC123456',
+      { doi: '10.1097/ACM.0000000000002209', pmid: '29538103' },
+      { fetchFn }
+    );
+
+    expect(result).toBe('match');
+  });
+
+  it('falls back to title comparison when no identifiers overlap', async () => {
+    const fetchFn = mockFetchJson(
+      esummaryResponse({
+        uid: '123456',
+        title: 'Harnessing the power of big data to improve graduate medical education: big idea or bust?',
+      })
+    );
+
+    const result = await verifyPmcid(
+      'PMC123456',
+      {
+        title:
+          'Harnessing the Power of Big Data to Improve Graduate Medical Education: Big Idea or Bust?',
+      },
+      { fetchFn }
+    );
+
+    expect(result).toBe('match');
+  });
+
+  it('returns mismatch when only titles are comparable and they differ', async () => {
+    const fetchFn = mockFetchJson(
+      esummaryResponse({ uid: '123456', title: 'A Completely Different Paper' })
+    );
+
+    const result = await verifyPmcid(
+      'PMC123456',
+      { title: 'Harnessing the Power of Big Data' },
+      { fetchFn }
+    );
+
+    expect(result).toBe('mismatch');
+  });
+
+  it('returns unverified when the article has no comparable fields', async () => {
+    const fetchFn = mockFetchJson(esummaryResponse({ uid: '123456' }));
+
+    const result = await verifyPmcid('PMC123456', {}, { fetchFn });
+
+    expect(result).toBe('unverified');
+  });
+
+  it('returns unverified when the esummary request fails', async () => {
+    const fetchFn = vi.fn(async () =>
+      new Response('server error', { status: 500 })
+    ) as unknown as typeof fetch;
+
+    const result = await verifyPmcid(
+      'PMC123456',
+      { doi: '10.1234/example' },
+      { fetchFn }
+    );
+
+    expect(result).toBe('unverified');
+  });
+
+  it('returns unverified when fetch throws', async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch;
+
+    const result = await verifyPmcid(
+      'PMC123456',
+      { doi: '10.1234/example' },
+      { fetchFn }
+    );
+
+    expect(result).toBe('unverified');
+  });
+
+  it('accepts a bare numeric PMCID', async () => {
+    const fetchFn = mockFetchJson(
+      esummaryResponse({ uid: '123456', doi: '10.1234/example' })
+    );
+
+    const result = await verifyPmcid(
+      '123456',
+      { doi: '10.1234/example' },
+      { fetchFn }
+    );
+
+    expect(result).toBe('match');
+    const calledUrl = String(vi.mocked(fetchFn).mock.calls[0]?.[0]);
+    expect(calledUrl).toContain('id=123456');
+    expect(calledUrl).toContain('db=pmc');
+  });
+
+  it('passes tool and email params to the esummary request', async () => {
+    const fetchFn = mockFetchJson(
+      esummaryResponse({ uid: '123456', doi: '10.1234/example' })
+    );
+
+    await verifyPmcid(
+      'PMC123456',
+      { doi: '10.1234/example' },
+      { fetchFn, ncbiTool: 'search-hub', ncbiEmail: 'test@example.com' }
+    );
+
+    const calledUrl = String(vi.mocked(fetchFn).mock.calls[0]?.[0]);
+    expect(calledUrl).toContain('tool=search-hub');
+    expect(calledUrl).toContain('email=test%40example.com');
+  });
+});

--- a/src/cli/commands/fulltext/verify-pmcid.ts
+++ b/src/cli/commands/fulltext/verify-pmcid.ts
@@ -1,0 +1,113 @@
+/**
+ * PMCID verification against source article metadata.
+ *
+ * OA discovery can resolve a PMCID that belongs to a different paper
+ * (e.g. a citing article returned by elink). Before attaching PMC
+ * locations to an article, cross-check the PMC record's DOI/PMID/title
+ * against the source article via NCBI esummary (issue #146).
+ */
+
+const ESUMMARY_URL = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi';
+
+export interface PmcidVerifyArticle {
+  doi?: string;
+  pmid?: string;
+  title?: string;
+}
+
+export type PmcidVerification = 'match' | 'mismatch' | 'unverified';
+
+export interface VerifyPmcidOptions {
+  ncbiEmail?: string;
+  ncbiTool?: string;
+  /** Injectable fetch for testing */
+  fetchFn?: typeof fetch;
+}
+
+interface EsummaryArticleId {
+  idtype?: string;
+  value?: string;
+}
+
+interface EsummaryRecord {
+  title?: string;
+  articleids?: EsummaryArticleId[];
+}
+
+/** Lowercase a DOI and strip url/prefix decorations for comparison. */
+function normalizeDoi(doi: string): string {
+  return doi
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\/(dx\.)?doi\.org\//, '')
+    .replace(/^doi:/, '');
+}
+
+/** Reduce a title to lowercase alphanumerics for tolerant comparison. */
+function normalizeTitle(title: string): string {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+/** Fetch the esummary record for a PMC ID. Returns null on any failure. */
+async function fetchPmcRecord(
+  pmcid: string,
+  options: VerifyPmcidOptions
+): Promise<EsummaryRecord | null> {
+  const numericId = pmcid.replace(/^PMC/i, '');
+  const params = new URLSearchParams({ db: 'pmc', id: numericId, retmode: 'json' });
+  if (options.ncbiTool) params.set('tool', options.ncbiTool);
+  if (options.ncbiEmail) params.set('email', options.ncbiEmail);
+
+  const fetchFn = options.fetchFn ?? fetch;
+  try {
+    const response = await fetchFn(`${ESUMMARY_URL}?${params.toString()}`);
+    if (!response.ok) return null;
+    const data = (await response.json()) as {
+      result?: Record<string, unknown>;
+    };
+    const record = data.result?.[numericId];
+    if (!record || typeof record !== 'object') return null;
+    return record as EsummaryRecord;
+  } catch {
+    return null;
+  }
+}
+
+function findArticleId(record: EsummaryRecord, idtype: string): string | undefined {
+  return record.articleids?.find((id) => id.idtype === idtype)?.value;
+}
+
+/**
+ * Verify that a PMCID actually refers to the given article.
+ * Compares by DOI first, then PMID, then normalized title.
+ * Returns 'unverified' when the PMC record cannot be fetched or
+ * shares no comparable field with the article.
+ */
+export async function verifyPmcid(
+  pmcid: string,
+  article: PmcidVerifyArticle,
+  options: VerifyPmcidOptions = {}
+): Promise<PmcidVerification> {
+  const record = await fetchPmcRecord(pmcid, options);
+  if (!record) return 'unverified';
+
+  const recordDoi = findArticleId(record, 'doi');
+  if (article.doi && recordDoi) {
+    return normalizeDoi(article.doi) === normalizeDoi(recordDoi) ? 'match' : 'mismatch';
+  }
+
+  const recordPmid = findArticleId(record, 'pmid');
+  if (article.pmid && recordPmid) {
+    return article.pmid.trim() === recordPmid.trim() ? 'match' : 'mismatch';
+  }
+
+  if (article.title && record.title) {
+    const articleTitle = normalizeTitle(article.title);
+    const recordTitle = normalizeTitle(record.title);
+    if (articleTitle && recordTitle) {
+      return articleTitle === recordTitle ? 'match' : 'mismatch';
+    }
+  }
+
+  return 'unverified';
+}


### PR DESCRIPTION
## Summary

Fixes #146 — `fulltext check` could attach a completely unrelated PMC ID to an article, causing `fulltext fetch`/`convert` to register a different paper's fulltext.

Two-layer fix:

1. **Root cause — dependency bump**: `@ncukondo/academic-fulltext` 0.2.0's `lookupPmcid` picked the first elink linkset with `dbto=pmc`, which for articles not in PMC is `pubmed_pmc_refs` (papers **citing** the article). 0.2.3+ filters by `linkname=pubmed_pmc`. Bumped to ^0.2.6.

2. **Defense in depth — PMCID validation** (`verify-pmcid.ts`): before trusting a PMCID discovered during OA check, fetch its NCBI esummary (db=pmc) and cross-check DOI → PMID → normalized title against the source article.
   - **mismatch**: all PMC locations are dropped (never written to `meta.json`), oaStatus downgraded to `unknown` if nothing remains, and a warning is printed with the rejected PMCID.
   - **match**: the verified PMCID is persisted to `meta.json` (if not already set) so `fetch` can use it.
   - **unverified** (network/API failure): locations kept, PMCID not vouched for.

## Verification

- 16 new unit tests (11 for `verifyPmcid`, 5 for check integration); all 2426 unit tests pass, typecheck and lint clean.
- E2E against live NCBI with the exact case from #146: PMC12928693 vs PMID 29538103 → `mismatch` (rejected); PMC11802295 vs its own DOI/PMID → `match`; title-only fallback → `match`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MY2UQM85gbned9uV5ftKYi