### PR TITLE
fix: stop swapping author family/given when registering reviewed articles

### DIFF
--- a/src/cli/commands/register.test.ts
+++ b/src/cli/commands/register.test.ts
@@ -621,6 +621,116 @@ articles:
       expect(article.source).toBe('pubmed');
     });
 
+    it('parses "Family Initial" author format without swapping family/given (issue #145)', async () => {
+      const sessionId = 'test-session';
+      const sessionDir = join(sessionsDir, sessionId);
+      const internalDir = join(sessionDir, '.internal');
+      await mkdir(internalDir, { recursive: true });
+
+      // reviews.yaml stores authors as "Family GivenInitial" (see review init formatAuthors)
+      const reviewContent = `
+sessionId: test-session
+articles:
+  - pmid: "12345"
+    title: "Test Article"
+    authors: "Schaye V, Jay S"
+    year: "2026"
+    reviews: []
+    finalDecision: include
+    mergedFrom:
+      - source: pubmed
+        pmid: "12345"
+`;
+      await writeFile(join(internalDir, 'reviews.yaml'), reviewContent);
+
+      const result = await getIncludedArticles(sessionId, sessionsDir);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.authors).toEqual([
+        { family: 'Schaye', given: 'V' },
+        { family: 'Jay', given: 'S' },
+      ]);
+    });
+
+    it('parses multi-word family names with a trailing initial', async () => {
+      const sessionId = 'test-session';
+      const sessionDir = join(sessionsDir, sessionId);
+      const internalDir = join(sessionDir, '.internal');
+      await mkdir(internalDir, { recursive: true });
+
+      const reviewContent = `
+sessionId: test-session
+articles:
+  - pmid: "12345"
+    title: "Test Article"
+    authors: "van der Berg V, Smith JD"
+    reviews: []
+    finalDecision: include
+    mergedFrom:
+      - source: pubmed
+        pmid: "12345"
+`;
+      await writeFile(join(internalDir, 'reviews.yaml'), reviewContent);
+
+      const result = await getIncludedArticles(sessionId, sessionsDir);
+
+      expect(result[0]!.authors).toEqual([
+        { family: 'van der Berg', given: 'V' },
+        { family: 'Smith', given: 'JD' },
+      ]);
+    });
+
+    it('parses single-word author names as family only', async () => {
+      const sessionId = 'test-session';
+      const sessionDir = join(sessionsDir, sessionId);
+      const internalDir = join(sessionDir, '.internal');
+      await mkdir(internalDir, { recursive: true });
+
+      const reviewContent = `
+sessionId: test-session
+articles:
+  - pmid: "12345"
+    title: "Test Article"
+    authors: "Smith"
+    reviews: []
+    finalDecision: include
+    mergedFrom:
+      - source: pubmed
+        pmid: "12345"
+`;
+      await writeFile(join(internalDir, 'reviews.yaml'), reviewContent);
+
+      const result = await getIncludedArticles(sessionId, sessionsDir);
+
+      expect(result[0]!.authors).toEqual([{ family: 'Smith' }]);
+    });
+
+    it('falls back to "Given Family" parsing when no trailing initials', async () => {
+      const sessionId = 'test-session';
+      const sessionDir = join(sessionsDir, sessionId);
+      const internalDir = join(sessionDir, '.internal');
+      await mkdir(internalDir, { recursive: true });
+
+      // Manually edited entry with full given name
+      const reviewContent = `
+sessionId: test-session
+articles:
+  - pmid: "12345"
+    title: "Test Article"
+    authors: "Verity Schaye"
+    reviews: []
+    finalDecision: include
+    mergedFrom:
+      - source: pubmed
+        pmid: "12345"
+`;
+      await writeFile(join(internalDir, 'reviews.yaml'), reviewContent);
+
+      const result = await getIncludedArticles(sessionId, sessionsDir);
+
+      expect(result[0]!.authors).toEqual([{ family: 'Schaye', given: 'Verity' }]);
+    });
+
     it('gets source from mergedFrom when available', async () => {
       const sessionId = 'test-session';
       const sessionDir = join(sessionsDir, sessionId);

--- a/src/cli/commands/register.ts
+++ b/src/cli/commands/register.ts
@@ -269,14 +269,24 @@ export async function getReviewSummary(sessionId: string, sessionsDir: string): 
 
 /**
  * Parse author name string into Author object.
- * Simple heuristic: last word is family name, rest is given name.
+ *
+ * reviews.yaml stores authors as "Family GivenInitial" (see formatAuthors in
+ * review/init.ts), so a trailing run of 1-3 uppercase letters is treated as
+ * the given-name initials and everything before it as the family name.
+ * Otherwise falls back to "Given Family" (e.g. manually edited entries).
  */
 function parseAuthorName(name: string): Author {
   const parts = name.trim().split(/\s+/);
   if (parts.length === 1) {
     return { family: parts[0] ?? '' };
   }
-  // Last part is family name (most common pattern in scientific citations)
+
+  const last = parts[parts.length - 1]!;
+  if (/^[A-Z]{1,3}$/.test(last)) {
+    parts.pop();
+    return { family: parts.join(' '), given: last };
+  }
+
   const family = parts.pop() ?? '';
   const given = parts.join(' ');
   return { family, given };


### PR DESCRIPTION
## Summary

`search-hub register --reviewed` emitted CSL-JSON (`references.json`) with author `family`/`given` swapped — the surname landed in `given` and the given-name initial in `family` (e.g. `{"family": "V", "given": "Schaye"}`), which also produced broken one-letter citation keys like `v-2026`.

Closes #145

## Root cause

The bug is in search-hub itself, not in the PubMed provider or any external library:

- `review init` writes authors to `reviews.yaml` as a `"Family GivenInitial"` string (`formatAuthors` in `src/cli/commands/review/init.ts`), e.g. `"Schaye V, Jay S"`.
- When registering reviewed articles, `parseAuthorName` in `src/cli/commands/register.ts` parsed that string assuming a `"Given Family"` order (last word = family name), so the initial became the family name and the surname became the given name.

The raw `pubmed_results.jsonl` is correct because the provider parser maps LastName/ForeName properly; only the reviews.yaml round-trip in the `--reviewed` register path swapped the names. The `--all` path (which reads result files directly) was unaffected.

## Fix

`parseAuthorName` now recognizes a trailing run of 1–3 uppercase letters as the given-name initials and treats everything before it as the family name, so multi-word family names (`"van der Berg V"`) are preserved. Names without trailing initials (e.g. manually edited entries like `"Verity Schaye"`) still fall back to the previous `"Given Family"` heuristic.

## Tests (TDD)

Added regression tests to `src/cli/commands/register.test.ts` (written first, confirmed failing with the exact swap from the issue, then fixed):

- `"Schaye V, Jay S"` → `[{family: "Schaye", given: "V"}, {family: "Jay", given: "S"}]`
- `"van der Berg V, Smith JD"` → multi-word family and multi-letter initials
- `"Smith"` → family only
- `"Verity Schaye"` → fallback `"Given Family"` parsing

Also verified end-to-end: a fixture `reviews.yaml` run through `getIncludedArticles` → `articlesToCslJson` now yields `{"family": "Schaye", "given": "V"}` and citekey `schaye-2026` (previously `v-2026`).

Full unit suite: 2414 passed. Typecheck and lint clean (lint warnings are pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQGHfUWZJe7eFXio1dCCUx