### PR TITLE
fix: resolve authors from structured session results when registering

### DIFF
--- a/src/cli/commands/register.test.ts
+++ b/src/cli/commands/register.test.ts
@@ -830,6 +830,305 @@ articles:
         /mergedFrom.*empty/i
       );
     });
+
+    describe('structured authors from session results (issue #149)', () => {
+      it('uses structured authors from results matched by pmid, restoring full given names', async () => {
+        const sessionId = 'test-session';
+        const sessionDir = join(sessionsDir, sessionId);
+        const internalDir = join(sessionDir, '.internal');
+        await mkdir(internalDir, { recursive: true });
+
+        const resultArticles = [
+          {
+            title: 'Test Article',
+            authors: [
+              { family: 'Schaye', given: 'Verity' },
+              { family: 'Jay', given: 'Stephen' },
+            ],
+            pmid: '12345',
+            source: 'pubmed',
+            retrievedAt: '2026-01-01T00:00:00Z',
+          },
+        ];
+        await writeFile(
+          join(sessionDir, 'pubmed_results.jsonl'),
+          resultArticles.map((a) => JSON.stringify(a)).join('\n')
+        );
+
+        // reviews.yaml only keeps the lossy display string
+        const reviewContent = `
+sessionId: test-session
+articles:
+  - pmid: "12345"
+    title: "Test Article"
+    authors: "Schaye V, Jay S"
+    reviews: []
+    finalDecision: include
+    mergedFrom:
+      - source: pubmed
+        pmid: "12345"
+`;
+        await writeFile(join(internalDir, 'reviews.yaml'), reviewContent);
+
+        const result = await getIncludedArticles(sessionId, sessionsDir);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]!.authors).toEqual([
+          { family: 'Schaye', given: 'Verity' },
+          { family: 'Jay', given: 'Stephen' },
+        ]);
+      });
+
+      it('preserves non-ASCII given names that the string round-trip would corrupt', async () => {
+        const sessionId = 'test-session';
+        const sessionDir = join(sessionsDir, sessionId);
+        const internalDir = join(sessionDir, '.internal');
+        await mkdir(internalDir, { recursive: true });
+
+        const resultArticles = [
+          {
+            title: 'Test Article',
+            authors: [{ family: 'Dupont', given: 'Émile' }],
+            doi: '10.1000/x',
+            source: 'scopus',
+            retrievedAt: '2026-01-01T00:00:00Z',
+          },
+        ];
+        await writeFile(
+          join(sessionDir, 'scopus_results.jsonl'),
+          resultArticles.map((a) => JSON.stringify(a)).join('\n')
+        );
+
+        // "Dupont É" would be mis-parsed as {family: "É", given: "Dupont"}
+        const reviewContent = `
+sessionId: test-session
+articles:
+  - doi: "10.1000/x"
+    title: "Test Article"
+    authors: "Dupont É"
+    reviews: []
+    finalDecision: include
+    mergedFrom:
+      - source: scopus
+        doi: "10.1000/x"
+`;
+        await writeFile(join(internalDir, 'reviews.yaml'), reviewContent);
+
+        const result = await getIncludedArticles(sessionId, sessionsDir);
+
+        expect(result[0]!.authors).toEqual([{ family: 'Dupont', given: 'Émile' }]);
+      });
+
+      it('matches DOIs case-insensitively', async () => {
+        const sessionId = 'test-session';
+        const sessionDir = join(sessionsDir, sessionId);
+        const internalDir = join(sessionDir, '.internal');
+        await mkdir(internalDir, { recursive: true });
+
+        const resultArticles = [
+          {
+            title: 'Test Article',
+            authors: [{ family: 'Smith', given: 'Jane' }],
+            doi: '10.1000/ABC',
+            source: 'scopus',
+            retrievedAt: '2026-01-01T00:00:00Z',
+          },
+        ];
+        await writeFile(
+          join(sessionDir, 'scopus_results.jsonl'),
+          resultArticles.map((a) => JSON.stringify(a)).join('\n')
+        );
+
+        const reviewContent = `
+sessionId: test-session
+articles:
+  - doi: "10.1000/abc"
+    title: "Test Article"
+    authors: "Smith J"
+    reviews: []
+    finalDecision: include
+    mergedFrom:
+      - source: scopus
+        doi: "10.1000/abc"
+`;
+        await writeFile(join(internalDir, 'reviews.yaml'), reviewContent);
+
+        const result = await getIncludedArticles(sessionId, sessionsDir);
+
+        expect(result[0]!.authors).toEqual([{ family: 'Smith', given: 'Jane' }]);
+      });
+
+      it('matches via mergedFrom identifiers when entry-level identifiers differ', async () => {
+        const sessionId = 'test-session';
+        const sessionDir = join(sessionsDir, sessionId);
+        const internalDir = join(sessionDir, '.internal');
+        await mkdir(internalDir, { recursive: true });
+
+        // The pubmed record has only a pmid; the merged entry surfaces only a doi
+        const resultArticles = [
+          {
+            title: 'Test Article',
+            authors: [{ family: 'Yamada', given: 'Taro' }],
+            pmid: '99999',
+            source: 'pubmed',
+            retrievedAt: '2026-01-01T00:00:00Z',
+          },
+        ];
+        await writeFile(
+          join(sessionDir, 'pubmed_results.jsonl'),
+          resultArticles.map((a) => JSON.stringify(a)).join('\n')
+        );
+
+        const reviewContent = `
+sessionId: test-session
+articles:
+  - doi: "10.1000/merged"
+    title: "Test Article"
+    authors: "Yamada T"
+    reviews: []
+    finalDecision: include
+    mergedFrom:
+      - source: scopus
+        doi: "10.1000/merged"
+      - source: pubmed
+        pmid: "99999"
+`;
+        await writeFile(join(internalDir, 'reviews.yaml'), reviewContent);
+
+        const result = await getIncludedArticles(sessionId, sessionsDir);
+
+        expect(result[0]!.authors).toEqual([{ family: 'Yamada', given: 'Taro' }]);
+      });
+
+      it('falls back to parsing the authors string when the article is not in the results', async () => {
+        const sessionId = 'test-session';
+        const sessionDir = join(sessionsDir, sessionId);
+        const internalDir = join(sessionDir, '.internal');
+        await mkdir(internalDir, { recursive: true });
+
+        const resultArticles = [
+          {
+            title: 'Some Other Article',
+            authors: [{ family: 'Other', given: 'Person' }],
+            pmid: '11111',
+            source: 'pubmed',
+            retrievedAt: '2026-01-01T00:00:00Z',
+          },
+        ];
+        await writeFile(
+          join(sessionDir, 'pubmed_results.jsonl'),
+          resultArticles.map((a) => JSON.stringify(a)).join('\n')
+        );
+
+        // Manually added article that never came from a search result
+        const reviewContent = `
+sessionId: test-session
+articles:
+  - pmid: "22222"
+    title: "Manually Added Article"
+    authors: "Schaye V"
+    reviews: []
+    finalDecision: include
+    mergedFrom:
+      - source: pubmed
+        pmid: "22222"
+`;
+        await writeFile(join(internalDir, 'reviews.yaml'), reviewContent);
+
+        const result = await getIncludedArticles(sessionId, sessionsDir);
+
+        expect(result[0]!.authors).toEqual([{ family: 'Schaye', given: 'V' }]);
+      });
+
+      it('falls back to the authors string when the matched result has no authors', async () => {
+        const sessionId = 'test-session';
+        const sessionDir = join(sessionsDir, sessionId);
+        const internalDir = join(sessionDir, '.internal');
+        await mkdir(internalDir, { recursive: true });
+
+        const resultArticles = [
+          {
+            title: 'Test Article',
+            authors: [],
+            pmid: '12345',
+            source: 'pubmed',
+            retrievedAt: '2026-01-01T00:00:00Z',
+          },
+        ];
+        await writeFile(
+          join(sessionDir, 'pubmed_results.jsonl'),
+          resultArticles.map((a) => JSON.stringify(a)).join('\n')
+        );
+
+        // Authors string was filled in by hand after the fact
+        const reviewContent = `
+sessionId: test-session
+articles:
+  - pmid: "12345"
+    title: "Test Article"
+    authors: "Schaye V"
+    reviews: []
+    finalDecision: include
+    mergedFrom:
+      - source: pubmed
+        pmid: "12345"
+`;
+        await writeFile(join(internalDir, 'reviews.yaml'), reviewContent);
+
+        const result = await getIncludedArticles(sessionId, sessionsDir);
+
+        expect(result[0]!.authors).toEqual([{ family: 'Schaye', given: 'V' }]);
+      });
+
+      it('prefers the YAML mirror over JSONL when both exist', async () => {
+        const sessionId = 'test-session';
+        const sessionDir = join(sessionsDir, sessionId);
+        const internalDir = join(sessionDir, '.internal');
+        await mkdir(internalDir, { recursive: true });
+
+        const jsonlArticles = [
+          {
+            title: 'Test Article',
+            authors: [{ family: 'Old', given: 'Name' }],
+            pmid: '12345',
+            source: 'pubmed',
+            retrievedAt: '2026-01-01T00:00:00Z',
+          },
+        ];
+        await writeFile(
+          join(sessionDir, 'pubmed_results.jsonl'),
+          jsonlArticles.map((a) => JSON.stringify(a)).join('\n')
+        );
+        const yamlContent = `
+- title: "Test Article"
+  authors:
+    - family: "Corrected"
+      given: "Name"
+  pmid: "12345"
+  source: pubmed
+  retrievedAt: "2026-01-01T00:00:00Z"
+`;
+        await writeFile(join(sessionDir, 'pubmed_results.yaml'), yamlContent);
+
+        const reviewContent = `
+sessionId: test-session
+articles:
+  - pmid: "12345"
+    title: "Test Article"
+    authors: "Corrected N"
+    reviews: []
+    finalDecision: include
+    mergedFrom:
+      - source: pubmed
+        pmid: "12345"
+`;
+        await writeFile(join(internalDir, 'reviews.yaml'), reviewContent);
+
+        const result = await getIncludedArticles(sessionId, sessionsDir);
+
+        expect(result[0]!.authors).toEqual([{ family: 'Corrected', given: 'Name' }]);
+      });
+    });
   });
 
   describe('formatReviewRequiredMessage', () => {

--- a/src/cli/commands/register.test.ts
+++ b/src/cli/commands/register.test.ts
@@ -1000,6 +1000,124 @@ articles:
         expect(result[0]!.authors).toEqual([{ family: 'Yamada', given: 'Taro' }]);
       });
 
+      it('matches via arxivId when the article has no pmid/doi', async () => {
+        const sessionId = 'test-session';
+        const sessionDir = join(sessionsDir, sessionId);
+        const internalDir = join(sessionDir, '.internal');
+        await mkdir(internalDir, { recursive: true });
+
+        const resultArticles = [
+          {
+            title: 'Preprint Article',
+            authors: [{ family: 'Nakamura', given: 'Hanako' }],
+            arxivId: '2401.12345',
+            source: 'arxiv',
+            retrievedAt: '2026-01-01T00:00:00Z',
+          },
+        ];
+        await writeFile(
+          join(sessionDir, 'arxiv_results.jsonl'),
+          resultArticles.map((a) => JSON.stringify(a)).join('\n')
+        );
+
+        const reviewContent = `
+sessionId: test-session
+articles:
+  - arxivId: "2401.12345"
+    title: "Preprint Article"
+    authors: "Nakamura H"
+    reviews: []
+    finalDecision: include
+    mergedFrom:
+      - source: arxiv
+        arxivId: "2401.12345"
+`;
+        await writeFile(join(internalDir, 'reviews.yaml'), reviewContent);
+
+        const result = await getIncludedArticles(sessionId, sessionsDir);
+
+        expect(result[0]!.authors).toEqual([{ family: 'Nakamura', given: 'Hanako' }]);
+      });
+
+      it('matches via ericId when the article has no pmid/doi', async () => {
+        const sessionId = 'test-session';
+        const sessionDir = join(sessionsDir, sessionId);
+        const internalDir = join(sessionDir, '.internal');
+        await mkdir(internalDir, { recursive: true });
+
+        const resultArticles = [
+          {
+            title: 'Education Article',
+            authors: [{ family: 'García', given: 'María' }],
+            ericId: 'EJ1234567',
+            source: 'eric',
+            retrievedAt: '2026-01-01T00:00:00Z',
+          },
+        ];
+        await writeFile(
+          join(sessionDir, 'eric_results.jsonl'),
+          resultArticles.map((a) => JSON.stringify(a)).join('\n')
+        );
+
+        const reviewContent = `
+sessionId: test-session
+articles:
+  - ericId: "EJ1234567"
+    title: "Education Article"
+    authors: "García M"
+    reviews: []
+    finalDecision: include
+    mergedFrom:
+      - source: eric
+        ericId: "EJ1234567"
+`;
+        await writeFile(join(internalDir, 'reviews.yaml'), reviewContent);
+
+        const result = await getIncludedArticles(sessionId, sessionsDir);
+
+        expect(result[0]!.authors).toEqual([{ family: 'García', given: 'María' }]);
+      });
+
+      it('matches via scopusId recorded only in mergedFrom', async () => {
+        const sessionId = 'test-session';
+        const sessionDir = join(sessionsDir, sessionId);
+        const internalDir = join(sessionDir, '.internal');
+        await mkdir(internalDir, { recursive: true });
+
+        // The scopus record has only a scopusId; the merged entry surfaces no
+        // matching entry-level identifier for it
+        const resultArticles = [
+          {
+            title: 'Scopus Article',
+            authors: [{ family: 'Okafor', given: 'Chidi' }],
+            scopusId: '2-s2.0-99999',
+            source: 'scopus',
+            retrievedAt: '2026-01-01T00:00:00Z',
+          },
+        ];
+        await writeFile(
+          join(sessionDir, 'scopus_results.jsonl'),
+          resultArticles.map((a) => JSON.stringify(a)).join('\n')
+        );
+
+        const reviewContent = `
+sessionId: test-session
+articles:
+  - title: "Scopus Article"
+    authors: "Okafor C"
+    reviews: []
+    finalDecision: include
+    mergedFrom:
+      - source: scopus
+        scopusId: "2-s2.0-99999"
+`;
+        await writeFile(join(internalDir, 'reviews.yaml'), reviewContent);
+
+        const result = await getIncludedArticles(sessionId, sessionsDir);
+
+        expect(result[0]!.authors).toEqual([{ family: 'Okafor', given: 'Chidi' }]);
+      });
+
       it('falls back to parsing the authors string when the article is not in the results', async () => {
         const sessionId = 'test-session';
         const sessionDir = join(sessionsDir, sessionId);

--- a/src/cli/commands/register.ts
+++ b/src/cli/commands/register.ts
@@ -296,19 +296,29 @@ function parseAuthorName(name: string): Author {
 }
 
 /**
- * Build pmid/doi lookup keys for matching a review entry (or one of its
+ * Build identifier lookup keys for matching a review entry (or one of its
  * mergedFrom sources) against articles in the session's result files.
+ * Covers the same identifiers as getArticleKeys in session-utils.ts.
  */
-function authorLookupKeys(ref: { pmid?: string | undefined; doi?: string | undefined }): string[] {
+function authorLookupKeys(ref: {
+  pmid?: string | undefined;
+  doi?: string | undefined;
+  arxivId?: string | undefined;
+  scopusId?: string | undefined;
+  ericId?: string | undefined;
+}): string[] {
   const keys: string[] = [];
   if (ref.pmid) keys.push(`pmid:${ref.pmid}`);
   if (ref.doi) keys.push(`doi:${ref.doi.toLowerCase()}`);
+  if (ref.arxivId) keys.push(`arxiv:${ref.arxivId}`);
+  if (ref.scopusId) keys.push(`scopus:${ref.scopusId}`);
+  if (ref.ericId) keys.push(`eric:${ref.ericId}`);
   return keys;
 }
 
 /**
  * Load structured author data from the session's search result files
- * (results.jsonl / YAML mirror), indexed by pmid/doi.
+ * (results.jsonl / YAML mirror), indexed by article identifiers.
  *
  * Only articles with non-empty author lists are indexed; the first result
  * seen for a given identifier wins.
@@ -338,9 +348,10 @@ async function buildAuthorLookup(
  * Resolve authors for a review entry.
  *
  * Prefers the structured author data from the session's search results,
- * matched by pmid/doi (both the entry's own identifiers and those recorded
- * in mergedFrom). Falls back to parsing the display string in reviews.yaml
- * for articles not found in the results (e.g. manually added entries).
+ * matched by identifier (both the entry's own identifiers and those
+ * recorded in mergedFrom). Falls back to parsing the display string in
+ * reviews.yaml for articles not found in the results (e.g. manually added
+ * entries).
  */
 function resolveAuthors(entry: ArticleEntry, lookup: Map<string, Author[]>): Author[] {
   const keys = [
@@ -361,8 +372,8 @@ function resolveAuthors(entry: ArticleEntry, lookup: Map<string, Author[]>): Aut
  * Converts from ArticleEntry format to Article format.
  *
  * Authors are taken from the session's structured search results when the
- * article can be matched by pmid/doi; the authors string in reviews.yaml is
- * only used as a fallback.
+ * article can be matched by identifier; the authors string in reviews.yaml
+ * is only used as a fallback.
  *
  * @throws Error if mergedFrom is missing or empty (indicates legacy review file)
  */

--- a/src/cli/commands/register.ts
+++ b/src/cli/commands/register.ts
@@ -9,8 +9,9 @@ import { constants } from 'node:fs';
 import { createInterface } from 'node:readline';
 import { parse as parseYaml } from 'yaml';
 import type { ProviderName, Article, Author } from '../../providers/base/types.js';
+import { loadResults } from '../../session/results-io.js';
 import { parseProviderNames } from '../utils/validation.js';
-import { classifyStatus, type ReviewFile } from './review/types.js';
+import { classifyStatus, type ArticleEntry, type ReviewFile } from './review/types.js';
 
 export interface RegisterCommandOptions {
   sessionId: string;
@@ -270,10 +271,12 @@ export async function getReviewSummary(sessionId: string, sessionsDir: string): 
 /**
  * Parse author name string into Author object.
  *
- * reviews.yaml stores authors as "Family GivenInitial" (see formatAuthors in
- * review/init.ts), so a trailing run of 1-3 uppercase letters is treated as
- * the given-name initials and everything before it as the family name.
- * Otherwise falls back to "Given Family" (e.g. manually edited entries).
+ * Fallback for articles that cannot be matched to the session's structured
+ * search results (e.g. manually added entries). reviews.yaml stores authors
+ * as "Family GivenInitial" (see formatAuthors in review/init.ts), so a
+ * trailing run of 1-3 uppercase letters is treated as the given-name initials
+ * and everything before it as the family name. Otherwise falls back to
+ * "Given Family" (e.g. manually edited entries).
  */
 function parseAuthorName(name: string): Author {
   const parts = name.trim().split(/\s+/);
@@ -293,8 +296,73 @@ function parseAuthorName(name: string): Author {
 }
 
 /**
+ * Build pmid/doi lookup keys for matching a review entry (or one of its
+ * mergedFrom sources) against articles in the session's result files.
+ */
+function authorLookupKeys(ref: { pmid?: string | undefined; doi?: string | undefined }): string[] {
+  const keys: string[] = [];
+  if (ref.pmid) keys.push(`pmid:${ref.pmid}`);
+  if (ref.doi) keys.push(`doi:${ref.doi.toLowerCase()}`);
+  return keys;
+}
+
+/**
+ * Load structured author data from the session's search result files
+ * (results.jsonl / YAML mirror), indexed by pmid/doi.
+ *
+ * Only articles with non-empty author lists are indexed; the first result
+ * seen for a given identifier wins.
+ */
+async function buildAuthorLookup(
+  sessionDir: string,
+  providers: Iterable<ProviderName>
+): Promise<Map<string, Author[]>> {
+  const lookup = new Map<string, Author[]>();
+
+  for (const provider of providers) {
+    const articles = await loadResults(sessionDir, provider);
+    for (const article of articles) {
+      if (!article.authors || article.authors.length === 0) continue;
+      for (const key of authorLookupKeys(article)) {
+        if (!lookup.has(key)) {
+          lookup.set(key, article.authors);
+        }
+      }
+    }
+  }
+
+  return lookup;
+}
+
+/**
+ * Resolve authors for a review entry.
+ *
+ * Prefers the structured author data from the session's search results,
+ * matched by pmid/doi (both the entry's own identifiers and those recorded
+ * in mergedFrom). Falls back to parsing the display string in reviews.yaml
+ * for articles not found in the results (e.g. manually added entries).
+ */
+function resolveAuthors(entry: ArticleEntry, lookup: Map<string, Author[]>): Author[] {
+  const keys = [
+    ...authorLookupKeys(entry),
+    ...(entry.mergedFrom ?? []).flatMap((source) => authorLookupKeys(source)),
+  ];
+
+  for (const key of keys) {
+    const authors = lookup.get(key);
+    if (authors) return authors;
+  }
+
+  return entry.authors ? entry.authors.split(/,\s*/).map(parseAuthorName) : [];
+}
+
+/**
  * Get articles with finalDecision='include' from review file.
  * Converts from ArticleEntry format to Article format.
+ *
+ * Authors are taken from the session's structured search results when the
+ * article can be matched by pmid/doi; the authors string in reviews.yaml is
+ * only used as a fallback.
  *
  * @throws Error if mergedFrom is missing or empty (indicates legacy review file)
  */
@@ -302,8 +370,19 @@ export async function getIncludedArticles(sessionId: string, sessionsDir: string
   const reviewFile = await loadReviewFile(sessionId, sessionsDir);
   const articles = reviewFile.articles ?? [];
 
-  return articles
-    .filter((entry) => entry.finalDecision === 'include')
+  const included = articles.filter((entry) => entry.finalDecision === 'include');
+
+  // Collect providers referenced by the included articles and index their
+  // structured author data from the session's result files.
+  const providers = new Set<ProviderName>();
+  for (const entry of included) {
+    for (const source of entry.mergedFrom ?? []) {
+      providers.add(source.source as ProviderName);
+    }
+  }
+  const authorLookup = await buildAuthorLookup(join(sessionsDir, sessionId), providers);
+
+  return included
     .map((entry): Article => {
       // Validate mergedFrom exists
       if (!entry.mergedFrom) {
@@ -320,9 +399,7 @@ export async function getIncludedArticles(sessionId: string, sessionsDir: string
         );
       }
 
-      const authors: Author[] = entry.authors
-        ? entry.authors.split(/,\s*/).map(parseAuthorName)
-        : [];
+      const authors = resolveAuthors(entry, authorLookup);
 
       // Get source from the first entry in mergedFrom
       const source = entry.mergedFrom[0]!.source as ProviderName;


### PR DESCRIPTION
## Summary

`register --reviewed` previously reconstructed authors by re-parsing the lossy display string stored in `reviews.yaml` (e.g. `"Schaye V"`). This had inherent limitations even after the heuristic fix in #148:

- Given names could never be recovered beyond the initial (`{family: "Schaye", given: "V"}` instead of `given: "Verity"`)
- Non-ASCII initials (e.g. `"Dupont É"`) failed the `/^[A-Z]{1,3}$/` initial check and left family/given swapped
- Short all-caps family names in manually edited entries were indistinguishable from initials

This PR makes `register` treat the session's search result files (`*_results.jsonl` / YAML mirror) as the canonical structured source for authors:

- Included articles from `reviews.yaml` are matched against the result files by **pmid/doi**, using both the entry-level identifiers and those recorded in `mergedFrom` (DOI matching is case-insensitive, consistent with `getArticleKeys`)
- Matched articles take their authors directly from the structured `{family, given}` data
- The `parseAuthorName` heuristic remains only as a fallback for articles that cannot be found in the results (e.g. manually added entries) or whose matched result has an empty author list
- The `reviews.yaml` schema is unchanged — it stays a human-review view while the result files remain the source of truth

## Test plan

- [x] New unit tests: pmid match with full given names, non-ASCII given names, case-insensitive DOI match, match via `mergedFrom` identifiers, fallback for unmatched articles, fallback for empty-author results, YAML-mirror preference
- [x] Full unit suite passes (2437 tests), typecheck and lint clean
- [x] Verified end-to-end with the real CLI against a synthetic session: `references.json` CSL-JSON contains `{family: "Schaye", given: "Verity"}` and `{family: "Dupont", given: "Émile"}` (previously `given: "V"` and swapped family/given respectively), and a manually added article still falls back to string parsing

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2pNtvpMR3xMXc7msYxcR8