### PR TITLE
feat: register articles with alternative identifiers (arXiv/ERIC/Scopus)

### DIFF
--- a/spec/tasks/20260712-01-register-alt-identifiers.md
+++ b/spec/tasks/20260712-01-register-alt-identifiers.md
@@ -60,15 +60,15 @@ Each step follows the TDD cycle: Red → Green → Refactor.
   - [x] Verify Red → Green, run `npm run lint && npm run typecheck`
   - [x] Acceptance: CSL-JSON items carry alternative identifiers in `custom`
 
-- [ ] Step 2: Relax registration gate in integration layer
-  - [ ] Write tests in `src/integration/register.test.ts`:
+- [x] Step 2: Relax registration gate in integration layer
+  - [x] Write tests in `src/integration/register.test.ts`:
     - article with only `arxivId` (or `ericId`, `scopusId`) is included in the
       bulk import, not counted as `noId`
     - article with no identifier at all is still counted as `noId` and skipped
-  - [ ] Update `hasIdentifier()` in `src/integration/register.ts` to accept
+  - [x] Update `hasIdentifier()` in `src/integration/register.ts` to accept
         `arxivId`/`scopusId`/`ericId`
-  - [ ] Verify Red → Green, lint/typecheck
-  - [ ] Acceptance: arXiv/ERIC/Scopus-only articles reach `refAddBulk`
+  - [x] Verify Red → Green, lint/typecheck
+  - [x] Acceptance: arXiv/ERIC/Scopus-only articles reach `refAddBulk`
 
 - [ ] Step 3: Update CLI dry-run display and skip messages
   - [ ] Write tests for `src/cli/commands/register.ts`:

--- a/spec/tasks/20260712-01-register-alt-identifiers.md
+++ b/spec/tasks/20260712-01-register-alt-identifiers.md
@@ -84,14 +84,14 @@ Each step follows the TDD cycle: Red → Green → Refactor.
 
 ### Final Step: E2E Integration Tests (MANDATORY)
 
-- [ ] Extend `src/integration/register.e2e.test.ts`:
+- [x] Extend `src/integration/register.e2e.test.ts`:
   - register flow with an arXiv-only article: appears in bulk import file,
     `custom.arxiv_id` present in written CSL-JSON
   - identifier-less article: skipped with `noId` count
-- [ ] Run full test suite: `npm test`
-- [ ] Manual verification: `search-hub register <session> --dry-run` output
+- [x] Run full test suite: `npm test`
+- [x] Manual verification: `search-hub register <session> --dry-run` output
       with a session containing arXiv/ERIC-only articles (if feasible)
-- [ ] Acceptance: All tests pass
+- [x] Acceptance: All tests pass
 
 ## Notes
 

--- a/spec/tasks/20260712-01-register-alt-identifiers.md
+++ b/spec/tasks/20260712-01-register-alt-identifiers.md
@@ -45,8 +45,8 @@ accurately.
 
 Each step follows the TDD cycle: Red → Green → Refactor.
 
-- [ ] Step 1: Emit alternative identifiers in CSL-JSON conversion
-  - [ ] Write tests in `src/integration/csl-json.test.ts`:
+- [x] Step 1: Emit alternative identifiers in CSL-JSON conversion
+  - [x] Write tests in `src/integration/csl-json.test.ts`:
     - `articleToCslJson` emits `custom: { arxiv_id }` when `article.arxivId` set
       (key name MUST be `arxiv_id` — reference-manager's duplicate detector and
       fulltext discovery read `custom.arxiv_id`)
@@ -55,10 +55,10 @@ Each step follows the TDD cycle: Red → Green → Refactor.
     - arXiv-only article gets `URL: https://arxiv.org/abs/{arxivId}` when
       article has no existing URL-worthy identifier (DOI absent)
     - ERIC-only article gets `URL: https://eric.ed.gov/?id={ericId}`
-  - [ ] Extend `CslJsonItem` type with `custom?` and `URL?`, implement in
+  - [x] Extend `CslJsonItem` type with `custom?` and `URL?`, implement in
         `articleToCslJson`
-  - [ ] Verify Red → Green, run `npm run lint && npm run typecheck`
-  - [ ] Acceptance: CSL-JSON items carry alternative identifiers in `custom`
+  - [x] Verify Red → Green, run `npm run lint && npm run typecheck`
+  - [x] Acceptance: CSL-JSON items carry alternative identifiers in `custom`
 
 - [ ] Step 2: Relax registration gate in integration layer
   - [ ] Write tests in `src/integration/register.test.ts`:

--- a/spec/tasks/20260712-01-register-alt-identifiers.md
+++ b/spec/tasks/20260712-01-register-alt-identifiers.md
@@ -70,17 +70,17 @@ Each step follows the TDD cycle: Red → Green → Refactor.
   - [x] Verify Red → Green, lint/typecheck
   - [x] Acceptance: arXiv/ERIC/Scopus-only articles reach `refAddBulk`
 
-- [ ] Step 3: Update CLI dry-run display and skip messages
-  - [ ] Write tests for `src/cli/commands/register.ts`:
+- [x] Step 3: Update CLI dry-run display and skip messages
+  - [x] Write tests for `src/cli/commands/register.ts`:
     - `formatDryRunOutput`: arXiv-only article listed under "Would register"
       with id shown as `arxiv:{id}` (analogous for `eric:`/`scopus:`)
     - skip message no longer says "no DOI or PMID" but "no identifier"
       and only truly identifier-less articles appear there
-  - [ ] Update `getRegistrationId()` to fall back to
+  - [x] Update `getRegistrationId()` to fall back to
         `arxiv:` / `eric:` / `scopus:` prefixed ids after PMID/DOI
-  - [ ] Update skip message wording in `formatDryRunOutput`
-  - [ ] Verify Red → Green, lint/typecheck
-  - [ ] Acceptance: dry-run and summary reflect the new behavior
+  - [x] Update skip message wording in `formatDryRunOutput`
+  - [x] Verify Red → Green, lint/typecheck
+  - [x] Acceptance: dry-run and summary reflect the new behavior
 
 ### Final Step: E2E Integration Tests (MANDATORY)
 

--- a/src/cli/commands/register.test.ts
+++ b/src/cli/commands/register.test.ts
@@ -213,7 +213,7 @@ describe('register command', () => {
 
       expect(output).toContain('Would register 2 reference');
       expect(output).toContain('1 article');
-      expect(output).toContain('no DOI or PMID');
+      expect(output).toContain('no identifier');
     });
 
     it('should list articles with their identifiers', () => {
@@ -250,7 +250,7 @@ describe('register command', () => {
       expect(output).toContain('Would register 0');
     });
 
-    it('should show title, source, and alternative IDs for no-ID articles', () => {
+    it('should list arXiv/ERIC-only articles under "Would register" with prefixed ids', () => {
       const articles = [
         { title: 'Article with arXiv', authors: [], source: 'arxiv' as const, retrievedAt: '', arxivId: '2401.12345' },
         { title: 'Article with ERIC', authors: [], source: 'eric' as const, retrievedAt: '', ericId: 'ED123456' },
@@ -258,13 +258,38 @@ describe('register command', () => {
 
       const output = formatDryRunOutput(articles);
 
-      expect(output).toContain('no DOI or PMID');
-      expect(output).toContain('"Article with arXiv"');
-      expect(output).toContain('source: arxiv');
-      expect(output).toContain('has: arxiv:2401.12345');
-      expect(output).toContain('"Article with ERIC"');
-      expect(output).toContain('source: eric');
-      expect(output).toContain('has: eric:ED123456');
+      expect(output).toContain('Would register 2 reference');
+      expect(output).toContain('arxiv:2401.12345: Article with arXiv');
+      expect(output).toContain('eric:ED123456: Article with ERIC');
+      expect(output).not.toContain('skipped');
+    });
+
+    it('should prefer PMID and DOI over alternative identifiers', () => {
+      const articles = [
+        { title: 'PMID beats arXiv', authors: [], source: 'pubmed' as const, retrievedAt: '', pmid: '12345678', arxivId: '2401.12345' },
+        { title: 'DOI beats ERIC', authors: [], source: 'eric' as const, retrievedAt: '', doi: '10.1234/test', ericId: 'ED123456' },
+      ];
+
+      const output = formatDryRunOutput(articles);
+
+      expect(output).toContain('pmid:12345678');
+      expect(output).not.toContain('arxiv:2401.12345');
+      expect(output).toContain('10.1234/test');
+      expect(output).not.toContain('eric:ED123456');
+    });
+
+    it('should skip only truly identifier-less articles with "no identifier" wording', () => {
+      const articles = [
+        { title: 'Article with arXiv', authors: [], source: 'arxiv' as const, retrievedAt: '', arxivId: '2401.12345' },
+        { title: 'Plain article', authors: [], source: 'pubmed' as const, retrievedAt: '' },
+      ];
+
+      const output = formatDryRunOutput(articles);
+
+      expect(output).toContain('1 article will be skipped (no identifier):');
+      expect(output).not.toContain('no DOI or PMID');
+      expect(output).toContain('"Plain article"');
+      expect(output).not.toContain('"Article with arXiv" (source');
     });
 
     it('should truncate no-ID article titles at 50 characters', () => {
@@ -299,7 +324,7 @@ describe('register command', () => {
       expect(output).toContain('... and 5 more');
     });
 
-    it('should show only title and source for no-ID articles without alternative IDs', () => {
+    it('should show only title and source for no-ID articles', () => {
       const articles = [
         { title: 'Plain Article', authors: [], source: 'pubmed' as const, retrievedAt: '' },
       ];
@@ -308,18 +333,17 @@ describe('register command', () => {
 
       expect(output).toContain('"Plain Article"');
       expect(output).toContain('source: pubmed');
-      expect(output).not.toContain('has:');
     });
 
-    it('should show scopus alternative ID for no-ID articles', () => {
+    it('should list Scopus-only articles under "Would register" with scopus: prefix', () => {
       const articles = [
         { title: 'Scopus Article', authors: [], source: 'scopus' as const, retrievedAt: '', scopusId: '2-s2.0-12345' },
       ];
 
       const output = formatDryRunOutput(articles);
 
-      expect(output).toContain('"Scopus Article"');
-      expect(output).toContain('has: scopus:2-s2.0-12345');
+      expect(output).toContain('Would register 1 reference');
+      expect(output).toContain('scopus:2-s2.0-12345: Scopus Article');
     });
   });
 

--- a/src/cli/commands/register.ts
+++ b/src/cli/commands/register.ts
@@ -116,7 +116,8 @@ export function formatRegistrationSummary(summary: {
 
 /**
  * Get registration identifier for an article.
- * PMID is preferred over DOI for better metadata quality.
+ * PMID is preferred over DOI for better metadata quality; alternative
+ * identifiers (arXiv/ERIC/Scopus) are used when neither is present.
  */
 function getRegistrationId(article: Article): string | null {
   if (article.pmid) {
@@ -124,6 +125,15 @@ function getRegistrationId(article: Article): string | null {
   }
   if (article.doi) {
     return article.doi;
+  }
+  if (article.arxivId) {
+    return `arxiv:${article.arxivId}`;
+  }
+  if (article.ericId) {
+    return `eric:${article.ericId}`;
+  }
+  if (article.scopusId) {
+    return `scopus:${article.scopusId}`;
   }
   return null;
 }
@@ -159,11 +169,11 @@ export function formatDryRunOutput(articles: Article[]): string {
     lines.push(`  - ${id}: ${title}`);
   }
 
-  // Details about articles without DOI/PMID
+  // Details about articles without any identifier
   if (withoutId.length > 0) {
     lines.push('');
     lines.push(
-      `${withoutId.length} article${withoutId.length !== 1 ? 's' : ''} will be skipped (no DOI or PMID):`
+      `${withoutId.length} article${withoutId.length !== 1 ? 's' : ''} will be skipped (no identifier):`
     );
 
     const maxDisplay = 10;
@@ -174,10 +184,7 @@ export function formatDryRunOutput(articles: Article[]): string {
         ? article.title.substring(0, 50) + '...'
         : article.title;
 
-      const altIds = getAlternativeIds(article);
-      const hasAltIds = altIds.length > 0 ? `, has: ${altIds.join(', ')}` : '';
-
-      lines.push(`  - "${truncatedTitle}" (source: ${article.source}${hasAltIds})`);
+      lines.push(`  - "${truncatedTitle}" (source: ${article.source})`);
     }
 
     if (withoutId.length > maxDisplay) {
@@ -186,17 +193,6 @@ export function formatDryRunOutput(articles: Article[]): string {
   }
 
   return lines.join('\n');
-}
-
-/**
- * Get alternative (non-DOI/PMID) identifiers for an article.
- */
-function getAlternativeIds(article: Article): string[] {
-  const ids: string[] = [];
-  if (article.arxivId) ids.push(`arxiv:${article.arxivId}`);
-  if (article.ericId) ids.push(`eric:${article.ericId}`);
-  if (article.scopusId) ids.push(`scopus:${article.scopusId}`);
-  return ids;
 }
 
 /**

--- a/src/integration/csl-json.test.ts
+++ b/src/integration/csl-json.test.ts
@@ -174,6 +174,96 @@ describe('articleToCslJson', () => {
     expect(csl.issue).toBeUndefined();
     expect(csl.page).toBeUndefined();
   });
+
+  describe('alternative identifiers (custom field)', () => {
+    it('should emit custom.arxiv_id when arxivId is set', () => {
+      const article = createArticle({ arxivId: '2401.12345' });
+
+      const csl = articleToCslJson(article, 'smith-2024');
+
+      // Key name MUST be arxiv_id — reference-manager's duplicate detector
+      // and fulltext discovery read custom.arxiv_id
+      expect(csl.custom).toEqual({ arxiv_id: '2401.12345' });
+    });
+
+    it('should emit custom.eric_id when ericId is set', () => {
+      const article = createArticle({ ericId: 'ED123456' });
+
+      const csl = articleToCslJson(article, 'smith-2024');
+
+      expect(csl.custom).toEqual({ eric_id: 'ED123456' });
+    });
+
+    it('should emit custom.scopus_id when scopusId is set', () => {
+      const article = createArticle({ scopusId: '2-s2.0-85012345678' });
+
+      const csl = articleToCslJson(article, 'smith-2024');
+
+      expect(csl.custom).toEqual({ scopus_id: '2-s2.0-85012345678' });
+    });
+
+    it('should emit all alternative identifiers together with DOI/PMID', () => {
+      const article = createArticle({
+        doi: '10.1234/test',
+        pmid: '12345678',
+        arxivId: '2401.12345',
+        ericId: 'ED123456',
+        scopusId: '2-s2.0-85012345678',
+      });
+
+      const csl = articleToCslJson(article, 'smith-2024');
+
+      expect(csl.DOI).toBe('10.1234/test');
+      expect(csl.PMID).toBe('12345678');
+      expect(csl.custom).toEqual({
+        arxiv_id: '2401.12345',
+        eric_id: 'ED123456',
+        scopus_id: '2-s2.0-85012345678',
+      });
+    });
+
+    it('should not emit custom field when article has no alternative identifiers', () => {
+      const article = createArticle({ doi: '10.1234/test', pmid: '12345678' });
+
+      const csl = articleToCslJson(article, 'smith-2024');
+
+      expect(csl).not.toHaveProperty('custom');
+    });
+  });
+
+  describe('URL for alternative-identifier-only articles', () => {
+    it('should set arXiv abstract URL for an arXiv-only article (no DOI)', () => {
+      const article = createArticle({ arxivId: '2401.12345' });
+
+      const csl = articleToCslJson(article, 'smith-2024');
+
+      expect(csl.URL).toBe('https://arxiv.org/abs/2401.12345');
+    });
+
+    it('should set ERIC URL for an ERIC-only article (no DOI)', () => {
+      const article = createArticle({ ericId: 'ED123456' });
+
+      const csl = articleToCslJson(article, 'smith-2024');
+
+      expect(csl.URL).toBe('https://eric.ed.gov/?id=ED123456');
+    });
+
+    it('should not set URL when article has a DOI', () => {
+      const article = createArticle({ doi: '10.1234/test', arxivId: '2401.12345' });
+
+      const csl = articleToCslJson(article, 'smith-2024');
+
+      expect(csl.URL).toBeUndefined();
+    });
+
+    it('should not set URL when article has no alternative identifiers', () => {
+      const article = createArticle({ pmid: '12345678' });
+
+      const csl = articleToCslJson(article, 'smith-2024');
+
+      expect(csl.URL).toBeUndefined();
+    });
+  });
 });
 
 describe('articlesToCslJson', () => {

--- a/src/integration/csl-json.ts
+++ b/src/integration/csl-json.ts
@@ -13,12 +13,22 @@ export interface CslJsonItem {
   author: Array<{ family: string; given?: string }>;
   DOI?: string;
   PMID?: string;
+  URL?: string;
   abstract?: string;
   issued?: { 'date-parts': number[][] };
   'container-title'?: string;
   volume?: string;
   issue?: string;
   page?: string;
+  /**
+   * Alternative identifiers. Key names match what reference-manager reads:
+   * its duplicate detector and fulltext discovery use `custom.arxiv_id`.
+   */
+  custom?: {
+    arxiv_id?: string;
+    eric_id?: string;
+    scopus_id?: string;
+  };
 }
 
 /**
@@ -87,6 +97,22 @@ export function articleToCslJson(article: Article, id: string): CslJsonItem {
 
   if (article.doi) item.DOI = article.doi;
   if (article.pmid) item.PMID = article.pmid;
+
+  const custom: NonNullable<CslJsonItem['custom']> = {};
+  if (article.arxivId) custom.arxiv_id = article.arxivId;
+  if (article.ericId) custom.eric_id = article.ericId;
+  if (article.scopusId) custom.scopus_id = article.scopusId;
+  if (Object.keys(custom).length > 0) item.custom = custom;
+
+  // Without a DOI, give resolvers a landing page for the alternative identifier
+  if (!article.doi) {
+    if (article.arxivId) {
+      item.URL = `https://arxiv.org/abs/${article.arxivId}`;
+    } else if (article.ericId) {
+      item.URL = `https://eric.ed.gov/?id=${article.ericId}`;
+    }
+  }
+
   if (article.abstract) item.abstract = article.abstract;
 
   const dateParts = parseDateParts(article.publicationDate);

--- a/src/integration/register.e2e.test.ts
+++ b/src/integration/register.e2e.test.ts
@@ -131,13 +131,14 @@ describe('register command e2e', () => {
     expect(result.stdout).toContain('pmid:87654321');
     expect(result.stdout).toContain('10.1234/test');
     expect(result.stdout).toContain('1 article');
-    expect(result.stdout).toContain('no DOI or PMID');
+    expect(result.stdout).toContain('no identifier');
   });
 
-  it('should show details for no-ID articles in dry-run', async () => {
+  it('should register alternative-ID articles and skip only no-ID articles in dry-run', async () => {
     await createTestSession(tempDir, sessionId, [
       { pmid: '12345678', title: 'Article with PMID' },
       { title: 'Article from arXiv', source: 'arxiv', arxivId: '2401.12345' },
+      { title: 'Article from ERIC', source: 'eric', ericId: 'ED123456' },
       { title: 'Plain article without any IDs' },
     ]);
 
@@ -147,12 +148,12 @@ describe('register command e2e', () => {
       { cwd: path.join(__dirname, '../..') }
     );
 
-    // Should show registrable count
-    expect(result.stdout).toContain('Would register 1 reference');
-    // Should show details for no-ID articles
-    expect(result.stdout).toContain('2 articles will be skipped (no DOI or PMID)');
-    expect(result.stdout).toContain('"Article from arXiv"');
-    expect(result.stdout).toContain('has: arxiv:2401.12345');
+    // arXiv/ERIC-only articles are now registrable
+    expect(result.stdout).toContain('Would register 3 reference');
+    expect(result.stdout).toContain('arxiv:2401.12345');
+    expect(result.stdout).toContain('eric:ED123456');
+    // Only the truly identifier-less article is skipped
+    expect(result.stdout).toContain('1 article will be skipped (no identifier)');
     expect(result.stdout).toContain('"Plain article without any IDs"');
     expect(result.stdout).toContain('source: pubmed');
   });
@@ -272,6 +273,105 @@ describe('register command e2e', () => {
     expect(result.stdout).toContain('pmid:11111111');
     expect(result.stdout).toContain('pmid:22222222');
     expect(result.stdout).not.toContain('ERIC Article');
+  });
+});
+
+// Tests using a stub ref command that captures the bulk import file.
+// This exercises the real CLI register flow end-to-end without needing
+// the actual reference-manager, and lets us inspect the CSL-JSON that
+// would be imported.
+describe('register with stubbed ref command', () => {
+  let tempDir: string;
+  let sessionId: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'search-hub-stub-e2e-'));
+    sessionId = '20240115_stub-test_xyz789';
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  /**
+   * Create an executable `ref` stub that copies the bulk import file to
+   * REF_STUB_CAPTURE and emits a valid RefAddOutput JSON for its content.
+   */
+  async function createRefStub(): Promise<string> {
+    const stubDir = path.join(tempDir, 'stub-bin');
+    await fs.mkdir(stubDir, { recursive: true });
+    const stubPath = path.join(stubDir, 'ref');
+    const script = `#!/usr/bin/env node
+const fs = require('fs');
+const args = process.argv.slice(2);
+if (args.includes('--version')) {
+  console.log('0.0.0-stub');
+  process.exit(0);
+}
+const i = args.indexOf('-i');
+const file = args[i + 2];
+fs.copyFileSync(file, process.env.REF_STUB_CAPTURE);
+const items = JSON.parse(fs.readFileSync(file, 'utf8'));
+const added = items.map((it) => ({ source: it.id, id: it.id, title: it.title }));
+console.log(JSON.stringify({
+  summary: { total: items.length, added: added.length, skipped: 0, failed: 0 },
+  added,
+  skipped: [],
+  failed: [],
+}));
+`;
+    await fs.writeFile(stubPath, script, { mode: 0o755 });
+    return stubDir;
+  }
+
+  it('should bulk-import arXiv-only articles with custom.arxiv_id and count identifier-less articles as noId', async () => {
+    await createTestSession(tempDir, sessionId, [
+      { pmid: '12345678', title: 'Article with PMID' },
+      { title: 'arXiv Only Article', source: 'arxiv', arxivId: '2401.12345' },
+      { title: 'Identifier-less Article' },
+    ]);
+
+    const captureFile = path.join(tempDir, 'captured_bulk_import.json');
+    const stubDir = await createRefStub();
+
+    const cliCmd = getCliCommand();
+    const result = await execAsync(
+      `${cliCmd} register ${sessionId} --session-dir ${tempDir} --no-attach-fulltext`,
+      {
+        cwd: path.join(__dirname, '../..'),
+        env: {
+          ...process.env,
+          PATH: `${stubDir}:${process.env['PATH']}`,
+          REF_STUB_CAPTURE: captureFile,
+        },
+      }
+    );
+
+    expect(result.stdout).toContain('Registration complete');
+
+    // The arXiv-only article appears in the bulk import file with custom.arxiv_id
+    const captured = JSON.parse(await fs.readFile(captureFile, 'utf-8')) as Array<{
+      title: string;
+      URL?: string;
+      custom?: { arxiv_id?: string };
+    }>;
+    expect(captured).toHaveLength(2);
+    const arxivItem = captured.find((item) => item.custom?.arxiv_id === '2401.12345');
+    expect(arxivItem).toBeDefined();
+    expect(arxivItem!.title).toBe('arXiv Only Article');
+    expect(arxivItem!.URL).toBe('https://arxiv.org/abs/2401.12345');
+
+    // The identifier-less article is skipped with noId count
+    const registrationPath = path.join(tempDir, sessionId, 'registration.json');
+    const registration = JSON.parse(await fs.readFile(registrationPath, 'utf-8'));
+    expect(registration.summary.total).toBe(3);
+    expect(registration.summary.added).toBe(2);
+    expect(registration.summary.noId).toBe(1);
+    expect(result.stdout).toContain('1 skipped (no identifier)');
   });
 });
 

--- a/src/integration/register.test.ts
+++ b/src/integration/register.test.ts
@@ -141,7 +141,7 @@ describe('registerArticles (bulk import)', () => {
   });
 
   describe('articles without identifiers', () => {
-    it('should count articles without DOI or PMID as noId and exclude from CSL-JSON', async () => {
+    it('should count articles without any identifier as noId and exclude from CSL-JSON', async () => {
       const articles = [
         createArticle({ title: 'No ID Article 1' }),
         createArticle({ title: 'No ID Article 2' }),
@@ -172,6 +172,103 @@ describe('registerArticles (bulk import)', () => {
       expect(mockRefAddBulk).not.toHaveBeenCalled();
       expect(result.summary.noId).toBe(1);
       expect(result.summary.added).toBe(0);
+    });
+  });
+
+  describe('articles with alternative identifiers', () => {
+    it('should include arXiv-only articles in the bulk import, not count as noId', async () => {
+      const articles = [
+        createArticle({
+          arxivId: '2401.12345',
+          title: 'arXiv Article',
+          authors: [{ family: 'Smith' }],
+          publicationDate: '2024',
+        }),
+      ];
+
+      mockRefAddBulk.mockImplementation(async (filePath: string) => {
+        const content = await fs.readFile(filePath, 'utf-8');
+        const cslJson = JSON.parse(content);
+        expect(cslJson).toHaveLength(1);
+        expect(cslJson[0].custom).toEqual({ arxiv_id: '2401.12345' });
+        return createBulkOutput([{ source: 'smith-2024', id: 'smith-2024', title: 'arXiv Article' }]);
+      });
+
+      const result = await registerArticles(articles, createOptions());
+
+      expect(mockRefAddBulk).toHaveBeenCalled();
+      expect(result.summary.noId).toBe(0);
+      expect(result.summary.added).toBe(1);
+    });
+
+    it('should include ERIC-only articles in the bulk import, not count as noId', async () => {
+      const articles = [
+        createArticle({
+          ericId: 'ED123456',
+          title: 'ERIC Article',
+          authors: [{ family: 'Jones' }],
+          publicationDate: '2024',
+        }),
+      ];
+
+      mockRefAddBulk.mockImplementation(async (filePath: string) => {
+        const content = await fs.readFile(filePath, 'utf-8');
+        const cslJson = JSON.parse(content);
+        expect(cslJson).toHaveLength(1);
+        expect(cslJson[0].custom).toEqual({ eric_id: 'ED123456' });
+        return createBulkOutput([{ source: 'jones-2024', id: 'jones-2024', title: 'ERIC Article' }]);
+      });
+
+      const result = await registerArticles(articles, createOptions());
+
+      expect(mockRefAddBulk).toHaveBeenCalled();
+      expect(result.summary.noId).toBe(0);
+      expect(result.summary.added).toBe(1);
+    });
+
+    it('should include Scopus-only articles in the bulk import, not count as noId', async () => {
+      const articles = [
+        createArticle({
+          scopusId: '2-s2.0-85012345678',
+          title: 'Scopus Article',
+          authors: [{ family: 'Chen' }],
+          publicationDate: '2024',
+        }),
+      ];
+
+      mockRefAddBulk.mockImplementation(async (filePath: string) => {
+        const content = await fs.readFile(filePath, 'utf-8');
+        const cslJson = JSON.parse(content);
+        expect(cslJson).toHaveLength(1);
+        expect(cslJson[0].custom).toEqual({ scopus_id: '2-s2.0-85012345678' });
+        return createBulkOutput([{ source: 'chen-2024', id: 'chen-2024', title: 'Scopus Article' }]);
+      });
+
+      const result = await registerArticles(articles, createOptions());
+
+      expect(mockRefAddBulk).toHaveBeenCalled();
+      expect(result.summary.noId).toBe(0);
+      expect(result.summary.added).toBe(1);
+    });
+
+    it('should count only truly identifier-less articles as noId in a mixed batch', async () => {
+      const articles = [
+        createArticle({ arxivId: '2401.12345', title: 'arXiv Article', authors: [{ family: 'Smith' }], publicationDate: '2024' }),
+        createArticle({ title: 'No ID Article' }),
+      ];
+
+      mockRefAddBulk.mockImplementation(async (filePath: string) => {
+        const content = await fs.readFile(filePath, 'utf-8');
+        const cslJson = JSON.parse(content);
+        expect(cslJson).toHaveLength(1);
+        return createBulkOutput([{ source: 'smith-2024', id: 'smith-2024', title: 'arXiv Article' }]);
+      });
+
+      const result = await registerArticles(articles, createOptions());
+
+      expect(result.summary.noId).toBe(1);
+      expect(result.summary.total).toBe(2);
+      expect(result.summary.added).toBe(1);
     });
   });
 

--- a/src/integration/register.ts
+++ b/src/integration/register.ts
@@ -64,11 +64,17 @@ export interface RegisterOptions {
 
 /**
  * Check if an article has an identifier suitable for registration.
- * Articles without DOI or PMID are included in CSL-JSON via metadata,
- * but we track them separately for the noId count.
+ * Any of DOI / PMID / arXiv ID / Scopus ID / ERIC ID qualifies;
+ * only articles with none of these are counted as noId and skipped.
  */
 function hasIdentifier(article: Article): boolean {
-  return !!(article.pmid || article.doi);
+  return !!(
+    article.pmid ||
+    article.doi ||
+    article.arxivId ||
+    article.scopusId ||
+    article.ericId
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #151.

`search-hub register` previously registered only articles with a DOI or PMID; arXiv/ERIC/Scopus-only articles were skipped with "skipped (no DOI or PMID)" even when their review decision was `include`. Articles with any of DOI / PMID / arXiv ID / ERIC ID / Scopus ID are now registered; only truly identifier-less articles are skipped, and messages say so accurately.

## Changes

- **CSL-JSON conversion** (`src/integration/csl-json.ts`): `articleToCslJson` now emits `custom.arxiv_id` / `custom.eric_id` / `custom.scopus_id` (key names match what reference-manager's duplicate detector and fulltext discovery read). Articles without a DOI get a landing-page `URL` for arXiv (`https://arxiv.org/abs/{id}`) or ERIC (`https://eric.ed.gov/?id={id}`).
- **Registration gate** (`src/integration/register.ts`): `hasIdentifier()` accepts arXiv/Scopus/ERIC IDs, so such articles reach `refAddBulk` instead of being counted as `noId`. `noId` now means "no identifier of any kind".
- **CLI dry-run display** (`src/cli/commands/register.ts`): `getRegistrationId()` falls back to `arxiv:` / `eric:` / `scopus:` prefixed ids after PMID/DOI, so these articles are listed under "Would register". Skip message wording changed from "no DOI or PMID" to "no identifier"; the `has: <alt-ids>` hint was removed because skipped articles can no longer have any identifiers.

Not changed (per task spec): citation key generation (`generateCslId`, already identifier-agnostic) and duplicate detection (lives in reference-manager; exact ERIC/Scopus matching tracked in ncukondo/reference-manager#98 — those articles are covered by the Title+Author+Year fallback).

## Test plan

- Unit tests for `custom`/`URL` emission, the relaxed `hasIdentifier()` gate, and the dry-run/skip display (TDD, Red → Green at each step).
- New e2e test drives the real CLI register flow against a stub `ref` command and inspects the captured bulk-import file: arXiv-only article present with `custom.arxiv_id` and arXiv URL; identifier-less article counted as `noId`.
- Manual verification: dry-run against a session containing arXiv/ERIC-only articles shows them under "Would register" as `arxiv:2401.12345` / `eric:ED654321`, with only the identifier-less article skipped.
- `npm run test:all`: unit + e2e all pass (3011 passed). One pre-existing failure in the live-API project (`src/providers/eric/eric.api.test.ts` "should return helpful error for unfielded phrase queries") is unrelated — the ERIC provider is untouched by this diff and the test fails identically on the base commit (live ERIC API behavior change). CI (`test:ci`) runs unit + e2e only.
- `npm run lint` (0 errors) and `npm run typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JUabf7seebX31pdv1Jxxw