### PR TITLE
feat: add self-upgrade command and update notification

### DIFF
--- a/spec/cli/commands.md
+++ b/spec/cli/commands.md
@@ -20,6 +20,7 @@ Commands:
   merge       Merge results from multiple sessions
   check       Verify coverage of known articles
   query       Query utilities (init, validate, translate, assess, log)
+  upgrade     Upgrade search-hub to the latest release
 ```
 
 ## Global Options
@@ -31,6 +32,7 @@ Commands:
 | `--verbose` | `-v` | Increase verbosity |
 | `--quiet` | `-q` | Suppress output |
 | `--no-color` | | Disable colors |
+| `--no-update-check` | | Disable the async update-version check |
 | `--help` | `-h` | Show help |
 | `--version` | `-V` | Show version |
 
@@ -836,6 +838,95 @@ $ search-hub merge merged-session new-session
 Error: Session 'merged-session' is a merged session (sources: v4, v9).
   Merge the original sources directly:
   search-hub merge v4 v9 new-session
+```
+
+---
+
+## upgrade
+
+Upgrade search-hub to the latest release (or a pinned version).
+
+### Syntax
+
+```bash
+search-hub upgrade [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--check` | Report current vs. latest version; perform no upgrade |
+| `--version <tag>` | Pin to a specific release tag (e.g. `v0.23.1`) |
+| `--yes`, `-y` | Skip confirmation prompts (npm-global strategy runs npm directly) |
+| `--install-dir <path>` | Override install dir for single-binary mode (default: directory of the running binary) |
+
+### Behavior
+
+Detects the install method from the resolved invocation path and applies the
+appropriate strategy:
+
+| Install method | Detection | Action |
+|---|---|---|
+| Single binary | Path outside `node_modules/`, typically `~/.local/bin/search-hub` (Bun-compiled binaries resolve via `process.execPath`) | Download `search-hub-{os}-{arch}[.exe]` from GitHub Releases, verify with `--version`, atomically replace the running binary |
+| npm global | Resolved path contains `node_modules/` | Print `npm i -g @ncukondo/search-hub@latest`; run it with `--yes` |
+| Dev / npx | Path inside a git worktree or npm cache (`_npx`) | Print guidance only |
+
+Release source: `https://github.com/ncukondo/search-hub/releases`.
+Binary replacement downloads to `{dest}.tmp.{pid}`, verifies the download by
+running `--version`, then moves it into place (on Windows the running `.exe`
+is rotated to `{dest}.old`).
+
+### Exit Codes (upgrade-specific)
+
+| Code | Meaning |
+|------|---------|
+| 0 | Already up to date, or upgrade completed successfully |
+| 1 | Upgrade failed (network, permissions, verification) |
+| 2 | Install method cannot be upgraded automatically (dev/npx) |
+
+### Update Notification
+
+After any normal command finishes, an async check compares the running
+version against the latest GitHub release. When a newer release exists, a
+one-line ASCII notice is printed to **stderr**:
+
+```
+>>> New version available: 0.23.1 -> 0.24.0
+    Run: search-hub upgrade
+```
+
+- The check result is cached for 24 hours at `{data}/update-check.json`
+  (search-hub's platform data dir); a fresh cache means no HTTP request.
+- Network failures are silent; the user's command output is never delayed.
+- GitHub rate-limit responses (403/429) fall back to the existing cache.
+
+Suppression rules — the check is skipped entirely (no network, no cache
+write) when any of:
+
+- stdout is not a TTY (machine-readable output such as `export`/`--json`
+  pipes is never contaminated)
+- `SEARCH_HUB_NO_UPDATE_CHECK=1` in env
+- `--no-update-check` flag passed
+- The running command is `upgrade` itself
+
+### Examples
+
+```bash
+# Upgrade to the latest release
+search-hub upgrade
+
+# Report current vs. latest without changing anything
+search-hub upgrade --check
+
+# Pin to a specific release
+search-hub upgrade --version v0.23.1
+
+# npm-global install: run npm without prompting
+search-hub upgrade -y
+
+# Single-binary install at a custom location
+search-hub upgrade --install-dir ~/bin
 ```
 
 ---

--- a/spec/tasks/20260712-02-self-upgrade.md
+++ b/spec/tasks/20260712-02-self-upgrade.md
@@ -95,15 +95,17 @@ do not start test suites from scratch.
         — verified via `node dist/cli/index.js upgrade --check` in the
         worktree: dev install detected, guidance printed, exit code 2
 
-- [ ] Step 5: `src/upgrade/notifier.ts` — async update notice
-  - [ ] Port tests: notice printed after command completes, all suppression
+- [x] Step 5: `src/upgrade/notifier.ts` — async update notice
+  - [x] Port tests: notice printed after command completes, all suppression
         rules (non-TTY, env var, flag, `upgrade` command)
-  - [ ] Hook into CLI entry; ensure notice never delays or corrupts command
+  - [x] Hook into CLI entry; ensure notice never delays or corrupts command
         output (search-hub prints JSON/YAML to stdout in several commands —
         notice must go to stderr or only print when stdout is a TTY;
         follow the reference spec's suppression rules strictly)
-  - [ ] Acceptance: `search-hub status` in a TTY with stale version shows
+  - [x] Acceptance: `search-hub status` in a TTY with stale version shows
         the one-line notice; piped output never contains it
+        — verified manually: `script`-simulated TTY + fresh fake cache with
+        latest=99.0.0 printed the notice; `status --json` piped had none
 
 - [ ] Step 6: Spec update
   - [ ] Add `upgrade` command to `spec/cli/commands.md` (options, exit codes,

--- a/spec/tasks/20260712-02-self-upgrade.md
+++ b/spec/tasks/20260712-02-self-upgrade.md
@@ -60,15 +60,18 @@ Each step follows the TDD cycle: Red → Green → Refactor. Port the
 reference-manager tests alongside each module and adapt constants/paths —
 do not start test suites from scratch.
 
-- [ ] Step 1: `src/upgrade/detect.ts` — install-method detection
-  - [ ] Port tests: binary (`~/.local/bin/search-hub`), npm-global, dev
+- [x] Step 1: `src/upgrade/detect.ts` — install-method detection
+  - [x] Port tests: binary (`~/.local/bin/search-hub`), npm-global, dev
         (repo checkout / npm link), npx heuristics
-  - [ ] Note: the single binary is Bun-compiled (`bun build --compile`,
+  - [x] Note: the single binary is Bun-compiled (`bun build --compile`,
         entry `src/cli/entry-bun.ts`); verify what `process.argv[1]` /
         `process.execPath` look like in a Bun-compiled binary and adjust
         detection accordingly (reference-manager may differ here — document
         what you find in code comments)
-  - [ ] Acceptance: unit tests cover all four methods
+        — Bun 1.x: `argv[1]` is a virtual `/$bunfs/root/...` (Unix) or
+        `B:\~BUN\root\...` (Windows) path; `process.execPath` is the real
+        binary. `resolveInvocationPath()` falls back to execPath for these.
+  - [x] Acceptance: unit tests cover all four methods
 
 - [ ] Step 2: `src/upgrade/check.ts` — latest-release lookup with cache
   - [ ] Port tests: GitHub API hit, 24h TTL cache read/write, network

--- a/spec/tasks/20260712-02-self-upgrade.md
+++ b/spec/tasks/20260712-02-self-upgrade.md
@@ -79,12 +79,12 @@ do not start test suites from scratch.
   - [x] Cache at search-hub's platform data dir as `update-check.json`
   - [x] Acceptance: no network call when cache is fresh
 
-- [ ] Step 3: `src/upgrade/apply-binary.ts` + `src/upgrade/apply-npm.ts`
-  - [ ] Port tests: asset URL construction
+- [x] Step 3: `src/upgrade/apply-binary.ts` + `src/upgrade/apply-npm.ts`
+  - [x] Port tests: asset URL construction
         (`https://github.com/ncukondo/search-hub/releases/download/{tag}/search-hub-{os}-{arch}`),
         download → chmod → atomic replace, already-up-to-date, `--check`,
         pinned `--version`, npm-global flow with `-y`
-  - [ ] Acceptance: strategies return the same `UpgradeResult` shape as
+  - [x] Acceptance: strategies return the same `UpgradeResult` shape as
         reference-manager
 
 - [ ] Step 4: `src/cli/commands/upgrade.ts` — command wiring

--- a/spec/tasks/20260712-02-self-upgrade.md
+++ b/spec/tasks/20260712-02-self-upgrade.md
@@ -73,11 +73,11 @@ do not start test suites from scratch.
         binary. `resolveInvocationPath()` falls back to execPath for these.
   - [x] Acceptance: unit tests cover all four methods
 
-- [ ] Step 2: `src/upgrade/check.ts` — latest-release lookup with cache
-  - [ ] Port tests: GitHub API hit, 24h TTL cache read/write, network
+- [x] Step 2: `src/upgrade/check.ts` — latest-release lookup with cache
+  - [x] Port tests: GitHub API hit, 24h TTL cache read/write, network
         failure silence
-  - [ ] Cache at search-hub's platform data dir as `update-check.json`
-  - [ ] Acceptance: no network call when cache is fresh
+  - [x] Cache at search-hub's platform data dir as `update-check.json`
+  - [x] Acceptance: no network call when cache is fresh
 
 - [ ] Step 3: `src/upgrade/apply-binary.ts` + `src/upgrade/apply-npm.ts`
   - [ ] Port tests: asset URL construction

--- a/spec/tasks/20260712-02-self-upgrade.md
+++ b/spec/tasks/20260712-02-self-upgrade.md
@@ -87,11 +87,13 @@ do not start test suites from scratch.
   - [x] Acceptance: strategies return the same `UpgradeResult` shape as
         reference-manager
 
-- [ ] Step 4: `src/cli/commands/upgrade.ts` — command wiring
-  - [ ] Port tests: option parsing, dev/npx guidance + exit code 2,
+- [x] Step 4: `src/cli/commands/upgrade.ts` — command wiring
+  - [x] Port tests: option parsing, dev/npx guidance + exit code 2,
         error exit code 1
-  - [ ] Register in `src/cli/index.ts`
-  - [ ] Acceptance: `search-hub upgrade --check` works end to end (manual)
+  - [x] Register in `src/cli/index.ts`
+  - [x] Acceptance: `search-hub upgrade --check` works end to end (manual)
+        — verified via `node dist/cli/index.js upgrade --check` in the
+        worktree: dev install detected, guidance printed, exit code 2
 
 - [ ] Step 5: `src/upgrade/notifier.ts` — async update notice
   - [ ] Port tests: notice printed after command completes, all suppression

--- a/spec/tasks/20260712-02-self-upgrade.md
+++ b/spec/tasks/20260712-02-self-upgrade.md
@@ -107,8 +107,8 @@ do not start test suites from scratch.
         — verified manually: `script`-simulated TTY + fresh fake cache with
         latest=99.0.0 printed the notice; `status --json` piped had none
 
-- [ ] Step 6: Spec update
-  - [ ] Add `upgrade` command to `spec/cli/commands.md` (options, exit codes,
+- [x] Step 6: Spec update
+  - [x] Add `upgrade` command to `spec/cli/commands.md` (options, exit codes,
         notification behavior, suppression rules)
 
 ### Final Step: E2E Integration Tests (MANDATORY)

--- a/spec/tasks/20260712-02-self-upgrade.md
+++ b/spec/tasks/20260712-02-self-upgrade.md
@@ -113,14 +113,21 @@ do not start test suites from scratch.
 
 ### Final Step: E2E Integration Tests (MANDATORY)
 
-- [ ] `src/upgrade/upgrade.e2e.test.ts` (or extend CLI e2e):
+- [x] `src/upgrade/upgrade.e2e.test.ts` (or extend CLI e2e):
   - full `upgrade --check` flow against a mocked GitHub API (no real network)
   - binary replace flow with a temp dir standing in for the install dir
   - notifier end-to-end with a fake cache file
-- [ ] Run full test suite: `npm test` (and `npm run test:all`)
-- [ ] Manual verification: build a local binary via `scripts/build-binary.sh`
+  - plus subprocess tests: dev guidance + exit 2, no notice in piped output
+- [x] Run full test suite: `npm test` (and `npm run test:all`)
+      — unit: all pass; e2e: all pass (register.e2e timeouts in the full
+      parallel run are pre-existing flakes; the file passes in isolation);
+      api: one pre-existing live-API ERIC failure unrelated to this change
+- [x] Manual verification: build a local binary via `scripts/build-binary.sh`
       and run `./dist/search-hub-* upgrade --check`
-- [ ] Acceptance: All tests pass
+      — inside worktree: dev guidance, exit 2 (execPath fallback works);
+      copied to a `.local/bin` dir with a fresh fake cache: binary strategy,
+      correct asset URL, exit 0
+- [x] Acceptance: All tests pass
 
 ## Notes
 

--- a/src/cli/commands/upgrade.test.ts
+++ b/src/cli/commands/upgrade.test.ts
@@ -1,0 +1,265 @@
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import type { UpgradeBinaryOptions, UpgradeResult } from '../../upgrade/apply-binary.js';
+import type { UpgradeNpmOptions } from '../../upgrade/apply-npm.js';
+import {
+  type RunUpgradeDeps,
+  type UpgradeCommandOptions,
+  formatUpgradeResult,
+  runUpgrade,
+} from './upgrade.js';
+
+function captureStream(): { stream: NodeJS.WritableStream; output: () => string } {
+  const stream = new PassThrough();
+  let buf = '';
+  stream.on('data', (chunk) => {
+    buf += String(chunk);
+  });
+  return { stream, output: () => buf };
+}
+
+function okResult(overrides: Partial<UpgradeResult> = {}): UpgradeResult {
+  return {
+    status: 'success',
+    fromVersion: '0.23.1',
+    toVersion: '0.24.0',
+    ...overrides,
+  };
+}
+
+function defaultDeps(overrides: Partial<RunUpgradeDeps> = {}): RunUpgradeDeps {
+  const { stream: stdout } = captureStream();
+  const { stream: stderr } = captureStream();
+  return {
+    installMethod: 'binary',
+    argv1: '/home/user/.local/bin/search-hub',
+    currentVersion: '0.23.1',
+    upgradeBinaryFn: vi.fn(async () => okResult()),
+    upgradeNpmFn: vi.fn(async () => okResult()),
+    stdout,
+    stderr,
+    ...overrides,
+  };
+}
+
+describe('runUpgrade', () => {
+  it("dispatches to the binary strategy when installMethod='binary'", async () => {
+    const upgradeBinaryFn = vi.fn(async () => okResult());
+    const upgradeNpmFn = vi.fn(async (_o: UpgradeNpmOptions) => okResult());
+    const result = await runUpgrade(
+      {} as UpgradeCommandOptions,
+      defaultDeps({
+        installMethod: 'binary',
+        upgradeBinaryFn,
+        upgradeNpmFn,
+      })
+    );
+
+    expect(upgradeBinaryFn).toHaveBeenCalledTimes(1);
+    expect(upgradeNpmFn).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(0);
+    expect(result.method).toBe('binary');
+  });
+
+  it("dispatches to the npm strategy when installMethod='npm-global'", async () => {
+    const upgradeBinaryFn = vi.fn(async (_o: UpgradeBinaryOptions) => okResult());
+    const upgradeNpmFn = vi.fn(async () => okResult({ status: 'guidance' }));
+    const result = await runUpgrade(
+      {} as UpgradeCommandOptions,
+      defaultDeps({
+        installMethod: 'npm-global',
+        upgradeBinaryFn,
+        upgradeNpmFn,
+      })
+    );
+
+    expect(upgradeBinaryFn).not.toHaveBeenCalled();
+    expect(upgradeNpmFn).toHaveBeenCalledTimes(1);
+    expect(result.exitCode).toBe(0);
+    expect(result.method).toBe('npm-global');
+  });
+
+  it('prints guidance and exits 2 for dev install', async () => {
+    const { stream: stderr, output } = captureStream();
+    const upgradeBinaryFn = vi.fn(async (_o: UpgradeBinaryOptions) => okResult());
+    const upgradeNpmFn = vi.fn(async (_o: UpgradeNpmOptions) => okResult());
+    const result = await runUpgrade(
+      {} as UpgradeCommandOptions,
+      defaultDeps({
+        installMethod: 'dev',
+        stderr,
+        upgradeBinaryFn,
+        upgradeNpmFn,
+      })
+    );
+
+    expect(upgradeBinaryFn).not.toHaveBeenCalled();
+    expect(upgradeNpmFn).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(2);
+    expect(output()).toMatch(/dev/i);
+  });
+
+  it('prints guidance and exits 2 for npx install', async () => {
+    const { stream: stderr, output } = captureStream();
+    const result = await runUpgrade(
+      {} as UpgradeCommandOptions,
+      defaultDeps({ installMethod: 'npx', stderr })
+    );
+
+    expect(result.exitCode).toBe(2);
+    expect(output()).toMatch(/npx/i);
+  });
+
+  it('passes --check through to the binary strategy without mutating anything', async () => {
+    const assetUrl =
+      'https://github.com/ncukondo/search-hub/releases/download/v0.24.0/search-hub-linux-x64';
+    const upgradeBinaryFn = vi.fn(async (_o: UpgradeBinaryOptions) =>
+      okResult({
+        status: 'guidance',
+        url: assetUrl,
+      })
+    );
+    const { stream: stdout, output } = captureStream();
+    const result = await runUpgrade(
+      { check: true } as UpgradeCommandOptions,
+      defaultDeps({ installMethod: 'binary', upgradeBinaryFn, stdout })
+    );
+
+    expect(upgradeBinaryFn).toHaveBeenCalledTimes(1);
+    const [firstCallArgs] = upgradeBinaryFn.mock.calls;
+    expect(firstCallArgs?.[0]).toMatchObject({ check: true });
+    expect(result.exitCode).toBe(0);
+    expect(output()).toContain(assetUrl);
+  });
+
+  it('passes --version and --yes through to the npm strategy', async () => {
+    const upgradeNpmFn = vi.fn(async (_o: UpgradeNpmOptions) => okResult());
+    await runUpgrade(
+      { version: 'v0.25.0', yes: true } as UpgradeCommandOptions,
+      defaultDeps({ installMethod: 'npm-global', upgradeNpmFn })
+    );
+
+    const [firstCall] = upgradeNpmFn.mock.calls;
+    expect(firstCall?.[0]).toMatchObject({ version: 'v0.25.0', yes: true });
+  });
+
+  it('resolves destPath for the binary strategy from argv1 (realpath)', async () => {
+    const upgradeBinaryFn = vi.fn(async (_o: UpgradeBinaryOptions) => okResult());
+    await runUpgrade(
+      {} as UpgradeCommandOptions,
+      defaultDeps({
+        installMethod: 'binary',
+        argv1: '/home/user/.local/bin/search-hub',
+        upgradeBinaryFn,
+      })
+    );
+
+    const [firstCall] = upgradeBinaryFn.mock.calls;
+    // destPath should be the resolved argv1 by default.
+    expect(firstCall?.[0].destPath).toContain('search-hub');
+  });
+
+  it('honors --install-dir override for the binary strategy', async () => {
+    const upgradeBinaryFn = vi.fn(async (_o: UpgradeBinaryOptions) => okResult());
+    await runUpgrade(
+      { installDir: '/opt/custom' } as UpgradeCommandOptions,
+      defaultDeps({ installMethod: 'binary', upgradeBinaryFn })
+    );
+
+    const [firstCall] = upgradeBinaryFn.mock.calls;
+    const expected = join(
+      '/opt/custom',
+      process.platform === 'win32' ? 'search-hub.exe' : 'search-hub'
+    );
+    expect(firstCall?.[0].destPath).toBe(expected);
+  });
+
+  it("exits 1 when the strategy returns status='error'", async () => {
+    const upgradeBinaryFn = vi.fn(async (): Promise<UpgradeResult> => ({
+      status: 'error',
+      fromVersion: '0.23.1',
+      error: 'boom',
+    }));
+    const result = await runUpgrade(
+      {} as UpgradeCommandOptions,
+      defaultDeps({ installMethod: 'binary', upgradeBinaryFn })
+    );
+
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('exits 0 when the strategy returns already-up-to-date', async () => {
+    const upgradeBinaryFn = vi.fn(async () => ({
+      status: 'already-up-to-date' as const,
+      fromVersion: '0.24.0',
+      toVersion: '0.24.0',
+    }));
+    const result = await runUpgrade(
+      {} as UpgradeCommandOptions,
+      defaultDeps({
+        installMethod: 'binary',
+        currentVersion: '0.24.0',
+        upgradeBinaryFn,
+      })
+    );
+
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe('formatUpgradeResult', () => {
+  it('formats a success result', () => {
+    const text = formatUpgradeResult({
+      status: 'success',
+      fromVersion: '0.23.1',
+      toVersion: '0.24.0',
+    });
+    expect(text).toMatch(/0\.23\.1/);
+    expect(text).toMatch(/0\.24\.0/);
+    expect(text).toMatch(/upgrade|upgraded/i);
+  });
+
+  it('formats an already-up-to-date result', () => {
+    const text = formatUpgradeResult({
+      status: 'already-up-to-date',
+      fromVersion: '0.24.0',
+      toVersion: '0.24.0',
+    });
+    expect(text).toMatch(/up.to.date/i);
+  });
+
+  it('formats a guidance result with the command', () => {
+    const text = formatUpgradeResult({
+      status: 'guidance',
+      fromVersion: '0.23.1',
+      toVersion: '0.24.0',
+      message: 'npm i -g @ncukondo/search-hub@latest',
+    });
+    expect(text).toContain('npm i -g @ncukondo/search-hub@latest');
+  });
+
+  it('appends the asset url for a binary guidance result (no message)', () => {
+    const url =
+      'https://github.com/ncukondo/search-hub/releases/download/v0.24.0/search-hub-linux-x64';
+    const text = formatUpgradeResult({
+      status: 'guidance',
+      fromVersion: '0.23.1',
+      toVersion: '0.24.0',
+      url,
+    });
+    expect(text).toContain('0.23.1');
+    expect(text).toContain('0.24.0');
+    expect(text).toContain(url);
+  });
+
+  it('formats an error result', () => {
+    const text = formatUpgradeResult({
+      status: 'error',
+      fromVersion: '0.23.1',
+      error: 'network down',
+    });
+    expect(text).toMatch(/error/i);
+    expect(text).toContain('network down');
+  });
+});

--- a/src/cli/commands/upgrade.ts
+++ b/src/cli/commands/upgrade.ts
@@ -1,0 +1,170 @@
+/**
+ * `search-hub upgrade` command — applies a new release via the detected
+ * install method.
+ *
+ * Exit codes: 0 = success / already up to date, 1 = upgrade failed,
+ * 2 = install method cannot be upgraded automatically (dev/npx).
+ */
+import { realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Command } from 'commander';
+import {
+  type UpgradeBinaryOptions,
+  type UpgradeResult,
+  upgradeBinary,
+} from '../../upgrade/apply-binary.js';
+import { type UpgradeNpmOptions, upgradeNpmGlobal } from '../../upgrade/apply-npm.js';
+import {
+  type InstallMethod,
+  detectInstallMethod,
+  resolveInvocationPath,
+} from '../../upgrade/detect.js';
+import { VERSION } from '../../version.js';
+
+export interface UpgradeCommandOptions {
+  check?: boolean;
+  version?: string;
+  yes?: boolean;
+  installDir?: string;
+}
+
+export interface RunUpgradeDeps {
+  installMethod?: InstallMethod;
+  argv1?: string;
+  currentVersion?: string;
+  upgradeBinaryFn?: (options: UpgradeBinaryOptions) => Promise<UpgradeResult>;
+  upgradeNpmFn?: (options: UpgradeNpmOptions) => Promise<UpgradeResult>;
+  stdout?: NodeJS.WritableStream;
+  stderr?: NodeJS.WritableStream;
+}
+
+export interface RunUpgradeResult {
+  exitCode: 0 | 1 | 2;
+  method: InstallMethod;
+  result?: UpgradeResult;
+}
+
+function resolveDestPath(argv1: string, installDir: string | undefined): string {
+  if (installDir) {
+    const basename = process.platform === 'win32' ? 'search-hub.exe' : 'search-hub';
+    return join(installDir, basename);
+  }
+  try {
+    return realpathSync(argv1);
+  } catch {
+    return argv1;
+  }
+}
+
+function devGuidance(method: 'dev' | 'npx'): string {
+  if (method === 'npx') {
+    return (
+      'Detected an npx invocation (cache-resident copy). `search-hub upgrade` does nothing here — ' +
+      'npx fetches the latest on each run, or pin a version with `npx @ncukondo/search-hub@<tag>`.\n'
+    );
+  }
+  return (
+    'Detected a dev install (npm link or in-tree). `search-hub upgrade` does not modify dev trees. ' +
+    'Use `git pull && npm run build` in the source checkout, or reinstall with `install.sh` ' +
+    'or `npm i -g @ncukondo/search-hub`.\n'
+  );
+}
+
+function exitCodeFor(status: UpgradeResult['status']): 0 | 1 {
+  return status === 'error' ? 1 : 0;
+}
+
+export function formatUpgradeResult(result: UpgradeResult): string {
+  const from = result.fromVersion ?? '?';
+  const to = result.toVersion ?? '?';
+  switch (result.status) {
+    case 'success':
+      return `Upgraded search-hub ${from} -> ${to}`;
+    case 'already-up-to-date':
+      return `Already up to date (${to})`;
+    case 'guidance': {
+      const base = result.message ?? `Update available: ${from} -> ${to}`;
+      return result.url ? `${base} (${result.url})` : base;
+    }
+    case 'error':
+      return `Error: ${result.error ?? 'upgrade failed'}`;
+  }
+}
+
+function buildBinaryOptions(
+  options: UpgradeCommandOptions,
+  argv1: string,
+  currentVersion: string
+): UpgradeBinaryOptions {
+  const destPath = resolveDestPath(argv1, options.installDir);
+  const out: UpgradeBinaryOptions = { destPath, currentVersion };
+  if (options.check !== undefined) out.check = options.check;
+  if (options.version !== undefined) out.version = options.version;
+  return out;
+}
+
+function buildNpmOptions(
+  options: UpgradeCommandOptions,
+  currentVersion: string
+): UpgradeNpmOptions {
+  const out: UpgradeNpmOptions = { currentVersion };
+  if (options.check !== undefined) out.check = options.check;
+  if (options.yes !== undefined) out.yes = options.yes;
+  if (options.version !== undefined) out.version = options.version;
+  return out;
+}
+
+export async function runUpgrade(
+  options: UpgradeCommandOptions,
+  deps: RunUpgradeDeps = {}
+): Promise<RunUpgradeResult> {
+  // resolveInvocationPath handles the Bun-compiled binary case where
+  // process.argv[1] is a virtual bunfs path (see src/upgrade/detect.ts).
+  const argv1 = deps.argv1 ?? resolveInvocationPath();
+  const installMethod = deps.installMethod ?? detectInstallMethod(deps.argv1);
+  const currentVersion = deps.currentVersion ?? VERSION;
+  const upgradeBinaryFn = deps.upgradeBinaryFn ?? upgradeBinary;
+  const upgradeNpmFn = deps.upgradeNpmFn ?? upgradeNpmGlobal;
+  const stdout = deps.stdout ?? process.stdout;
+  const stderr = deps.stderr ?? process.stderr;
+
+  if (installMethod === 'dev' || installMethod === 'npx') {
+    stderr.write(devGuidance(installMethod));
+    return { exitCode: 2, method: installMethod };
+  }
+
+  const result =
+    installMethod === 'binary'
+      ? await upgradeBinaryFn(buildBinaryOptions(options, argv1, currentVersion))
+      : await upgradeNpmFn(buildNpmOptions(options, currentVersion));
+
+  const target = result.status === 'error' ? stderr : stdout;
+  target.write(`${formatUpgradeResult(result)}\n`);
+
+  return { exitCode: exitCodeFor(result.status), method: installMethod, result };
+}
+
+export function registerUpgradeCommand(program: Command): void {
+  program
+    .command('upgrade')
+    .description('Upgrade search-hub to the latest release (or a pinned version)')
+    .option('--check', 'Report current vs. latest without applying any upgrade')
+    .option('--version <tag>', 'Pin to a specific release tag (e.g. v0.23.1)')
+    .option('-y, --yes', 'Skip confirmation prompts (applies to npm-global strategy)')
+    .option('--install-dir <path>', 'Override install directory for the single-binary strategy')
+    .addHelpText('after', `
+Exit codes:
+  0  Already up to date, or upgrade completed successfully
+  1  Upgrade failed (network, permissions, verification)
+  2  Install method cannot be upgraded automatically (dev/npx)
+
+Examples:
+  $ search-hub upgrade                   # Upgrade to the latest release
+  $ search-hub upgrade --check           # Report current vs. latest only
+  $ search-hub upgrade --version v0.23.1 # Pin to a specific release
+  $ search-hub upgrade -y                # npm-global: run npm without prompting`)
+    .action(async (options: UpgradeCommandOptions) => {
+      const result = await runUpgrade(options);
+      process.exitCode = result.exitCode;
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -176,6 +176,12 @@ import {
 import { type ReviewStatus } from './commands/review/types.js';
 import { registerFulltextCommands } from './commands/fulltext/index.js';
 import { registerUpgradeCommand } from './commands/upgrade.js';
+import { maybeStartUpdateCheck } from '../upgrade/notifier.js';
+import {
+  extractCommandName,
+  hasNoUpdateCheckFlag,
+  rewriteUpgradeVersionFlag,
+} from './utils/argv.js';
 
 import {
   parseRegisterOptions,
@@ -252,6 +258,7 @@ export function createProgram(): Command {
     .option('-v, --verbose', 'enable verbose output', false)
     .option('--quiet', 'suppress all output except errors', false)
     .option('--no-color', 'disable color output')
+    .option('--no-update-check', 'disable the update-version check')
     .addHelpText('after', `
 Workflow:
   1. query init → edit → validate / --dry-run        Query preparation
@@ -3256,7 +3263,19 @@ Examples:
  */
 export async function main(): Promise<void> {
   const program = createProgram();
-  await program.parseAsync(process.argv);
+
+  // `upgrade --version <tag>` would otherwise be consumed by the root
+  // `--version` flag; rewrite to the `=` form before parsing.
+  const argv = rewriteUpgradeVersionFlag(process.argv, program);
+
+  // Kick off the async update check before command dispatch. The notifier
+  // registers its own exit listener to print the notice (to stderr, TTY
+  // only) after the user's command completes.
+  maybeStartUpdateCheck(extractCommandName(argv, program), {
+    noUpdateCheck: hasNoUpdateCheckFlag(argv),
+  });
+
+  await program.parseAsync(argv);
 }
 
 // Run main if executed directly

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -175,6 +175,7 @@ import {
 } from './commands/review/finalize.js';
 import { type ReviewStatus } from './commands/review/types.js';
 import { registerFulltextCommands } from './commands/fulltext/index.js';
+import { registerUpgradeCommand } from './commands/upgrade.js';
 
 import {
   parseRegisterOptions,
@@ -3243,6 +3244,9 @@ Examples:
 
   // Register fulltext command group (init, sync, convert, check)
   registerFulltextCommands(program, getSessionsDir);
+
+  // Register upgrade command
+  registerUpgradeCommand(program);
 
   return program;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -180,6 +180,7 @@ import { maybeStartUpdateCheck } from '../upgrade/notifier.js';
 import {
   extractCommandName,
   hasNoUpdateCheckFlag,
+  hasQuietFlag,
   rewriteUpgradeVersionFlag,
 } from './utils/argv.js';
 
@@ -3273,6 +3274,7 @@ export async function main(): Promise<void> {
   // only) after the user's command completes.
   maybeStartUpdateCheck(extractCommandName(argv, program), {
     noUpdateCheck: hasNoUpdateCheckFlag(argv),
+    quiet: hasQuietFlag(argv),
   });
 
   await program.parseAsync(argv);

--- a/src/cli/utils/argv.test.ts
+++ b/src/cli/utils/argv.test.ts
@@ -1,6 +1,11 @@
 import { Command } from 'commander';
 import { describe, expect, it } from 'vitest';
-import { extractCommandName, hasNoUpdateCheckFlag, rewriteUpgradeVersionFlag } from './argv.js';
+import {
+  extractCommandName,
+  hasNoUpdateCheckFlag,
+  hasQuietFlag,
+  rewriteUpgradeVersionFlag,
+} from './argv.js';
 
 function makeProgram(): Command {
   const program = new Command();
@@ -51,6 +56,17 @@ describe('hasNoUpdateCheckFlag', () => {
 
   it('returns false when absent', () => {
     expect(hasNoUpdateCheckFlag(['node', 'cli.js', 'status'])).toBe(false);
+  });
+});
+
+describe('hasQuietFlag', () => {
+  it('detects --quiet anywhere after the script', () => {
+    expect(hasQuietFlag(['node', 'cli.js', 'status', '--quiet'])).toBe(true);
+    expect(hasQuietFlag(['node', 'cli.js', '--quiet', 'status'])).toBe(true);
+  });
+
+  it('returns false when absent', () => {
+    expect(hasQuietFlag(['node', 'cli.js', 'status'])).toBe(false);
   });
 });
 

--- a/src/cli/utils/argv.test.ts
+++ b/src/cli/utils/argv.test.ts
@@ -1,0 +1,88 @@
+import { Command } from 'commander';
+import { describe, expect, it } from 'vitest';
+import { extractCommandName, hasNoUpdateCheckFlag, rewriteUpgradeVersionFlag } from './argv.js';
+
+function makeProgram(): Command {
+  const program = new Command();
+  program
+    .name('search-hub')
+    .version('0.0.0')
+    .option('-c, --config <path>', 'path to config file')
+    .option('--session-dir <path>', 'path to session directory')
+    .option('-v, --verbose', 'enable verbose output', false);
+  return program;
+}
+
+describe('extractCommandName', () => {
+  it('returns the first non-option token after node and script', () => {
+    expect(extractCommandName(['node', 'cli.js', 'status'], makeProgram())).toBe('status');
+  });
+
+  it('skips boolean flags', () => {
+    expect(extractCommandName(['node', 'cli.js', '-v', 'search'], makeProgram())).toBe('search');
+  });
+
+  it('skips the value of value-taking global options', () => {
+    expect(
+      extractCommandName(['node', 'cli.js', '--config', 'upgrade', 'status'], makeProgram())
+    ).toBe('status');
+    expect(
+      extractCommandName(['node', 'cli.js', '--session-dir', 'upgrade'], makeProgram())
+    ).toBe('');
+  });
+
+  it('does not skip a value for --opt=value form', () => {
+    expect(
+      extractCommandName(['node', 'cli.js', '--config=x.toml', 'export'], makeProgram())
+    ).toBe('export');
+  });
+
+  it('returns empty string when no command is present', () => {
+    expect(extractCommandName(['node', 'cli.js'], makeProgram())).toBe('');
+    expect(extractCommandName(['node', 'cli.js', '--verbose'], makeProgram())).toBe('');
+  });
+});
+
+describe('hasNoUpdateCheckFlag', () => {
+  it('detects --no-update-check anywhere after the script', () => {
+    expect(hasNoUpdateCheckFlag(['node', 'cli.js', 'status', '--no-update-check'])).toBe(true);
+    expect(hasNoUpdateCheckFlag(['node', 'cli.js', '--no-update-check', 'status'])).toBe(true);
+  });
+
+  it('returns false when absent', () => {
+    expect(hasNoUpdateCheckFlag(['node', 'cli.js', 'status'])).toBe(false);
+  });
+});
+
+describe('rewriteUpgradeVersionFlag', () => {
+  it('rewrites `upgrade --version <tag>` to `--version=<tag>`', () => {
+    expect(rewriteUpgradeVersionFlag(['node', 'cli.js', 'upgrade', '--version', 'v1.2.3'], makeProgram())).toEqual(
+      ['node', 'cli.js', 'upgrade', '--version=v1.2.3']
+    );
+  });
+
+  it('leaves a bare `upgrade --version` (no value) alone', () => {
+    expect(rewriteUpgradeVersionFlag(['node', 'cli.js', 'upgrade', '--version'], makeProgram())).toEqual([
+      'node',
+      'cli.js',
+      'upgrade',
+      '--version',
+    ]);
+  });
+
+  it('does not rewrite for other commands', () => {
+    expect(rewriteUpgradeVersionFlag(['node', 'cli.js', 'status', '--version', 'x'], makeProgram())).toEqual([
+      'node',
+      'cli.js',
+      'status',
+      '--version',
+      'x',
+    ]);
+  });
+
+  it('does not consume a following option as the tag value', () => {
+    expect(rewriteUpgradeVersionFlag(['node', 'cli.js', 'upgrade', '--version', '--check'], makeProgram())).toEqual(
+      ['node', 'cli.js', 'upgrade', '--version', '--check']
+    );
+  });
+});

--- a/src/cli/utils/argv.ts
+++ b/src/cli/utils/argv.ts
@@ -1,0 +1,90 @@
+/**
+ * Argv helpers for the update-check notifier and the `upgrade` command.
+ *
+ * These run before Commander parses argv (the async update check starts
+ * before command dispatch), so they are best-effort token scanners.
+ */
+import type { Command } from 'commander';
+
+/**
+ * Collect flags (both `--long` and `-s`) for global options that take a value.
+ * Used by {@link extractCommandName} so the subcommand parser can skip the
+ * value after options like `--config <path>`.
+ */
+function collectValueTakingFlags(program: Command): Set<string> {
+  const flags = new Set<string>();
+  for (const opt of program.options) {
+    if (!opt.required && !opt.optional) continue;
+    if (opt.long) flags.add(opt.long);
+    if (opt.short) flags.add(opt.short);
+  }
+  return flags;
+}
+
+/**
+ * Extract the subcommand name from argv (best-effort).
+ *
+ * Skips global options that take a value so things like `--config upgrade`
+ * are not misread as the `upgrade` subcommand. The set of value-taking
+ * options is derived from the Commander program itself, so it stays in sync
+ * with the option definitions.
+ */
+export function extractCommandName(argv: string[], program: Command): string {
+  const valueTakingFlags = collectValueTakingFlags(program);
+  let skipNext = false;
+  for (let i = 2; i < argv.length; i++) {
+    const token = argv[i];
+    if (!token) continue;
+    if (skipNext) {
+      skipNext = false;
+      continue;
+    }
+    if (token.startsWith('-')) {
+      // `--opt=value` bundles its value, no skip needed.
+      if (!token.includes('=') && valueTakingFlags.has(token)) skipNext = true;
+      continue;
+    }
+    return token;
+  }
+  return '';
+}
+
+/**
+ * Best-effort detection of `--no-update-check` in argv, without relying on
+ * Commander having parsed yet (the async check starts before parseAsync).
+ */
+export function hasNoUpdateCheckFlag(argv: string[]): boolean {
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--no-update-check') return true;
+  }
+  return false;
+}
+
+/**
+ * Rewrite `search-hub upgrade --version <tag>` to `--version=<tag>`.
+ *
+ * The program has `.version(VERSION)` which registers a no-arg `--version`
+ * flag at the root. Commander's parser consumes the root `--version` before
+ * subcommand options, so the space-separated form is caught by the root
+ * (prints + exits) instead of reaching `upgrade`'s `--version <tag>`. The
+ * `=` form binds the value to the subcommand's option and sidesteps the
+ * root flag.
+ */
+export function rewriteUpgradeVersionFlag(argv: string[], program: Command): string[] {
+  if (extractCommandName(argv, program) !== 'upgrade') return argv;
+
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === '--version' && i + 1 < argv.length) {
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith('-')) {
+        out.push(`--version=${next}`);
+        i++;
+        continue;
+      }
+    }
+    if (token !== undefined) out.push(token);
+  }
+  return out;
+}

--- a/src/cli/utils/argv.ts
+++ b/src/cli/utils/argv.ts
@@ -61,6 +61,19 @@ export function hasNoUpdateCheckFlag(argv: string[]): boolean {
 }
 
 /**
+ * Best-effort detection of the global `--quiet` flag in argv, without relying
+ * on Commander having parsed yet (the async check starts before parseAsync).
+ * `--quiet` promises "suppress all output except errors", which includes the
+ * update notice.
+ */
+export function hasQuietFlag(argv: string[]): boolean {
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--quiet') return true;
+  }
+  return false;
+}
+
+/**
  * Rewrite `search-hub upgrade --version <tag>` to `--version=<tag>`.
  *
  * The program has `.version(VERSION)` which registers a no-arg `--version`

--- a/src/upgrade/apply-binary.test.ts
+++ b/src/upgrade/apply-binary.test.ts
@@ -1,0 +1,255 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type UpgradeBinaryOptions, computeAssetName, upgradeBinary } from './apply-binary.js';
+
+function makeFetchBinary(bytes: Uint8Array, status = 200): typeof globalThis.fetch {
+  return vi.fn(async () => {
+    return new Response(bytes, {
+      status,
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+  }) as unknown as typeof globalThis.fetch;
+}
+
+function makeFetchStatus(status: number): typeof globalThis.fetch {
+  return vi.fn(
+    async () =>
+      new Response('not found', {
+        status,
+        headers: { 'content-type': 'text/plain' },
+      })
+  ) as unknown as typeof globalThis.fetch;
+}
+
+describe('computeAssetName', () => {
+  it.each([
+    ['linux', 'x64', 'search-hub-linux-x64'],
+    ['linux', 'arm64', 'search-hub-linux-arm64'],
+    ['darwin', 'x64', 'search-hub-darwin-x64'],
+    ['darwin', 'arm64', 'search-hub-darwin-arm64'],
+    ['win32', 'x64', 'search-hub-windows-x64.exe'],
+  ])('platform=%s arch=%s -> %s', (platform, arch, expected) => {
+    expect(computeAssetName(platform as NodeJS.Platform, arch)).toBe(expected);
+  });
+
+  it('throws for unsupported platform', () => {
+    expect(() => computeAssetName('freebsd' as NodeJS.Platform, 'x64')).toThrow(/unsupported/i);
+  });
+
+  it('throws for unsupported arch', () => {
+    expect(() => computeAssetName('linux', 'ia32')).toThrow(/unsupported/i);
+  });
+});
+
+describe('upgradeBinary', () => {
+  let testDir: string;
+  let destPath: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `upgrade-binary-test-${randomUUID()}`);
+    mkdirSync(testDir, { recursive: true });
+    destPath = join(testDir, 'search-hub');
+    // Seed a fake existing binary so dest exists.
+    writeFileSync(destPath, 'old binary\n', { mode: 0o755 });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function baseOptions(overrides: Partial<UpgradeBinaryOptions> = {}): UpgradeBinaryOptions {
+    return {
+      destPath,
+      currentVersion: '0.23.1',
+      platform: 'linux',
+      arch: 'x64',
+      pid: 12345,
+      fetch: makeFetchBinary(new TextEncoder().encode('new binary contents')),
+      verifyBinary: vi.fn(async () => 'search-hub 0.24.0'),
+      getLatest: vi.fn(async () => ({
+        checkedAt: '2026-07-12T12:00:00Z',
+        latest: '0.24.0',
+        url: 'https://github.com/ncukondo/search-hub/releases/tag/v0.24.0',
+      })),
+      ...overrides,
+    };
+  }
+
+  it('downloads to {dest}.tmp.{pid}, verifies, then moves into place', async () => {
+    const verifyCalls: string[] = [];
+    const options = baseOptions({
+      verifyBinary: vi.fn(async (path: string) => {
+        verifyCalls.push(path);
+        return 'search-hub 0.24.0';
+      }),
+    });
+
+    const result = await upgradeBinary(options);
+
+    expect(result.status).toBe('success');
+    expect(result.fromVersion).toBe('0.23.1');
+    expect(result.toVersion).toBe('0.24.0');
+    expect(readFileSync(destPath, 'utf-8')).toBe('new binary contents');
+    // Temp file should not remain after success.
+    expect(existsSync(`${destPath}.tmp.12345`)).toBe(false);
+    // Verify was called against the .tmp path, not dest.
+    expect(verifyCalls).toEqual([`${destPath}.tmp.12345`]);
+  });
+
+  it('uses `--version <tag>` when provided, bypassing getLatest', async () => {
+    const getLatest = vi.fn();
+    const fetchFn = vi.fn(async (url: URL | string) => {
+      expect(String(url)).toContain('/download/v0.25.0/search-hub-linux-x64');
+      return new Response(new TextEncoder().encode('pinned binary'), { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await upgradeBinary(
+      baseOptions({
+        version: 'v0.25.0',
+        fetch: fetchFn,
+        getLatest,
+        verifyBinary: vi.fn(async () => 'search-hub 0.25.0'),
+      })
+    );
+
+    expect(result.status).toBe('success');
+    expect(result.toVersion).toBe('0.25.0');
+    expect(getLatest).not.toHaveBeenCalled();
+  });
+
+  it('accepts a `--version` tag without leading v', async () => {
+    const fetchFn = vi.fn(async (url: URL | string) => {
+      expect(String(url)).toContain('/download/v0.25.0/');
+      return new Response(new TextEncoder().encode('bin'), { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await upgradeBinary(baseOptions({ version: '0.25.0', fetch: fetchFn }));
+    expect(result.status).toBe('success');
+  });
+
+  it('returns already-up-to-date when latest equals current version', async () => {
+    const fetchFn = vi.fn();
+    const result = await upgradeBinary(
+      baseOptions({
+        currentVersion: '0.24.0',
+        fetch: fetchFn as unknown as typeof globalThis.fetch,
+      })
+    );
+
+    expect(result.status).toBe('already-up-to-date');
+    expect(result.fromVersion).toBe('0.24.0');
+    expect(result.toVersion).toBe('0.24.0');
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('returns guidance with asset URL when check=true', async () => {
+    const fetchFn = vi.fn();
+    const result = await upgradeBinary(
+      baseOptions({
+        check: true,
+        fetch: fetchFn as unknown as typeof globalThis.fetch,
+      })
+    );
+
+    expect(result.status).toBe('guidance');
+    expect(result.toVersion).toBe('0.24.0');
+    expect(result.url).toBe(
+      'https://github.com/ncukondo/search-hub/releases/download/v0.24.0/search-hub-linux-x64'
+    );
+    expect(fetchFn).not.toHaveBeenCalled();
+    // Dest untouched.
+    expect(readFileSync(destPath, 'utf-8')).toBe('old binary\n');
+  });
+
+  it('returns already-up-to-date in check mode when versions match', async () => {
+    const result = await upgradeBinary(
+      baseOptions({
+        check: true,
+        currentVersion: '0.24.0',
+        fetch: vi.fn() as unknown as typeof globalThis.fetch,
+      })
+    );
+
+    expect(result.status).toBe('already-up-to-date');
+    expect(result.toVersion).toBe('0.24.0');
+  });
+
+  it('surfaces the release URL in the error on download 404', async () => {
+    const result = await upgradeBinary(
+      baseOptions({
+        fetch: makeFetchStatus(404),
+      })
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/404/);
+    expect(result.error).toContain(
+      'https://github.com/ncukondo/search-hub/releases/download/v0.24.0/search-hub-linux-x64'
+    );
+    // Dest untouched on 404.
+    expect(readFileSync(destPath, 'utf-8')).toBe('old binary\n');
+  });
+
+  it('returns error when getLatest resolves to null and no version pinned', async () => {
+    const result = await upgradeBinary(
+      baseOptions({
+        getLatest: vi.fn(async () => null),
+      })
+    );
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/latest/i);
+  });
+
+  it('leaves the .tmp file in place and returns error when verification fails', async () => {
+    const result = await upgradeBinary(
+      baseOptions({
+        verifyBinary: vi.fn(async () => null),
+      })
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/verif/i);
+    // Tmp preserved so the user can inspect the broken download.
+    expect(existsSync(`${destPath}.tmp.12345`)).toBe(true);
+    // Dest not replaced.
+    expect(readFileSync(destPath, 'utf-8')).toBe('old binary\n');
+  });
+
+  it('on Windows, rotates dest to .old before moving new binary into place', async () => {
+    const winDest = join(testDir, 'search-hub.exe');
+    writeFileSync(winDest, 'old windows\n', { mode: 0o755 });
+
+    const result = await upgradeBinary(
+      baseOptions({
+        destPath: winDest,
+        platform: 'win32',
+        arch: 'x64',
+        fetch: makeFetchBinary(new TextEncoder().encode('new exe')),
+        verifyBinary: vi.fn(async () => 'search-hub 0.24.0'),
+      })
+    );
+
+    expect(result.status).toBe('success');
+    expect(readFileSync(winDest, 'utf-8')).toBe('new exe');
+    // Old binary should remain at .old for best-effort cleanup on next run.
+    expect(readFileSync(`${winDest}.old`, 'utf-8')).toBe('old windows\n');
+  });
+
+  it('propagates network errors without touching dest', async () => {
+    const result = await upgradeBinary(
+      baseOptions({
+        fetch: vi.fn(async () => {
+          throw new Error('network down');
+        }) as unknown as typeof globalThis.fetch,
+      })
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/network down/);
+    expect(readFileSync(destPath, 'utf-8')).toBe('old binary\n');
+    expect(existsSync(`${destPath}.tmp.12345`)).toBe(false);
+  });
+});

--- a/src/upgrade/apply-binary.test.ts
+++ b/src/upgrade/apply-binary.test.ts
@@ -5,6 +5,13 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type UpgradeBinaryOptions, computeAssetName, upgradeBinary } from './apply-binary.js';
 
+// Wrap rmSync in a pass-through spy so tests can assert the unix replace path
+// never unlinks dest before renaming over it (the rename must be atomic).
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, rmSync: vi.fn(actual.rmSync) };
+});
+
 function makeFetchBinary(bytes: Uint8Array, status = 200): typeof globalThis.fetch {
   return vi.fn(async () => {
     return new Response(bytes, {
@@ -97,6 +104,18 @@ describe('upgradeBinary', () => {
     expect(existsSync(`${destPath}.tmp.12345`)).toBe(false);
     // Verify was called against the .tmp path, not dest.
     expect(verifyCalls).toEqual([`${destPath}.tmp.12345`]);
+  });
+
+  it('replaces the unix binary with a single atomic rename (no prior unlink)', async () => {
+    vi.mocked(rmSync).mockClear();
+
+    const result = await upgradeBinary(baseOptions());
+
+    expect(result.status).toBe('success');
+    expect(readFileSync(destPath, 'utf-8')).toBe('new binary contents');
+    // renameSync overwrites atomically on POSIX; unlinking dest first would
+    // open a window with no binary on disk at all.
+    expect(rmSync).not.toHaveBeenCalled();
   });
 
   it('uses `--version <tag>` when provided, bypassing getLatest', async () => {

--- a/src/upgrade/apply-binary.ts
+++ b/src/upgrade/apply-binary.ts
@@ -1,0 +1,303 @@
+/**
+ * Binary upgrade strategy for `search-hub upgrade` on single-binary installs.
+ *
+ * Downloads the release asset for the current platform to
+ * `{dest}.tmp.{pid}`, verifies it by invoking `--version`, then atomically
+ * replaces the running binary. Replacing the running binary on Unix is safe
+ * because the kernel keeps the inode alive until open file descriptors close;
+ * on Windows the running `.exe` is rotated to `{dest}.old` instead.
+ */
+import { execFile } from 'node:child_process';
+import { chmodSync, existsSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { promisify } from 'node:util';
+import { type ReleaseInfo, getLatestVersion } from './check.js';
+
+const execFileAsync = promisify(execFile);
+
+const REPO = 'ncukondo/search-hub';
+
+export type UpgradeStatus = 'success' | 'already-up-to-date' | 'guidance' | 'error';
+
+export interface UpgradeResult {
+  status: UpgradeStatus;
+  fromVersion?: string;
+  toVersion?: string;
+  url?: string;
+  message?: string;
+  error?: string;
+}
+
+export interface UpgradeBinaryOptions {
+  /** Absolute path to the binary that should be replaced. */
+  destPath: string;
+  /** The version of the currently running `search-hub`, without leading `v`. */
+  currentVersion: string;
+  /** Explicit release tag (e.g. "v0.24.0" or "0.24.0"). When unset, uses `getLatest`. */
+  version?: string;
+  /** Report mode only: do not mutate anything. */
+  check?: boolean;
+  /** Defaults to `process.platform`. */
+  platform?: NodeJS.Platform;
+  /** Defaults to `process.arch`. */
+  arch?: string;
+  /** Defaults to `process.pid`. */
+  pid?: number;
+  /** Injection points. */
+  fetch?: typeof globalThis.fetch;
+  getLatest?: () => Promise<ReleaseInfo | null>;
+  /**
+   * Runs the downloaded binary's `--version` command and returns the stdout
+   * (or null on failure). Injected so unit tests don't execute real children.
+   */
+  verifyBinary?: (path: string) => Promise<string | null>;
+}
+
+export function computeAssetName(platform: NodeJS.Platform, arch: string): string {
+  const osName = mapPlatform(platform);
+  const archName = mapArch(arch);
+  const suffix = osName === 'windows' ? '.exe' : '';
+  return `search-hub-${osName}-${archName}${suffix}`;
+}
+
+function mapPlatform(platform: NodeJS.Platform): 'linux' | 'darwin' | 'windows' {
+  if (platform === 'linux') return 'linux';
+  if (platform === 'darwin') return 'darwin';
+  if (platform === 'win32') return 'windows';
+  throw new Error(`unsupported platform: ${platform}`);
+}
+
+function mapArch(arch: string): 'x64' | 'arm64' {
+  if (arch === 'x64') return 'x64';
+  if (arch === 'arm64') return 'arm64';
+  throw new Error(`unsupported arch: ${arch}`);
+}
+
+function normalizeTag(tag: string): string {
+  return tag.startsWith('v') ? tag : `v${tag}`;
+}
+
+function stripV(tag: string): string {
+  return tag.startsWith('v') ? tag.slice(1) : tag;
+}
+
+function buildAssetUrl(tag: string, assetName: string): string {
+  return `https://github.com/${REPO}/releases/download/${tag}/${assetName}`;
+}
+
+function errorResult(
+  fromVersion: string,
+  error: string,
+  extras: { toVersion?: string; url?: string } = {}
+): UpgradeResult {
+  return {
+    status: 'error',
+    fromVersion,
+    ...(extras.toVersion !== undefined && { toVersion: extras.toVersion }),
+    ...(extras.url !== undefined && { url: extras.url }),
+    error,
+  };
+}
+
+/**
+ * Default verifier: execs `{path} --version` with a short timeout. Returns the
+ * trimmed stdout on success, or null if the binary fails to run.
+ */
+async function defaultVerifyBinary(path: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(path, ['--version'], {
+      timeout: 5000,
+    });
+    const trimmed = stdout.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+interface ResolvedTarget {
+  targetTag: string;
+  targetVersion: string;
+  releaseHtmlUrl?: string;
+}
+
+async function resolveTarget(
+  pinnedVersion: string | undefined,
+  getLatest: () => Promise<ReleaseInfo | null>
+): Promise<ResolvedTarget | { error: string }> {
+  if (pinnedVersion) {
+    const targetTag = normalizeTag(pinnedVersion);
+    return { targetTag, targetVersion: stripV(targetTag) };
+  }
+  const release = await getLatest();
+  if (!release) {
+    return { error: 'Could not determine the latest release. Check your network connection.' };
+  }
+  const targetTag = normalizeTag(release.latest);
+  return {
+    targetTag,
+    targetVersion: stripV(targetTag),
+    releaseHtmlUrl: release.url,
+  };
+}
+
+async function downloadAsset(
+  url: string,
+  tmpPath: string,
+  fetchFn: typeof globalThis.fetch
+): Promise<{ error?: string }> {
+  let response: Response;
+  try {
+    response = await fetchFn(url);
+  } catch (error) {
+    return {
+      error: `Download failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  if (response.status === 404) {
+    return { error: `Download returned 404. Asset not found at: ${url}` };
+  }
+  if (!response.ok) {
+    return { error: `Download failed with HTTP ${response.status}: ${url}` };
+  }
+
+  try {
+    const buffer = Buffer.from(await response.arrayBuffer());
+    writeFileSync(tmpPath, buffer);
+    chmodSync(tmpPath, 0o755);
+  } catch (error) {
+    if (existsSync(tmpPath)) {
+      try {
+        rmSync(tmpPath, { force: true });
+      } catch {
+        // ignore
+      }
+    }
+    return {
+      error: `Failed to write downloaded binary: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+  return {};
+}
+
+function atomicReplace(
+  tmpPath: string,
+  destPath: string,
+  platform: NodeJS.Platform
+): { error?: string } {
+  try {
+    if (platform === 'win32') {
+      // The running .exe cannot be deleted on Windows: rotate it to `.old`
+      // (best-effort cleaned up on the next upgrade) before moving the new
+      // binary into place.
+      const oldPath = `${destPath}.old`;
+      if (existsSync(oldPath)) {
+        try {
+          rmSync(oldPath, { force: true });
+        } catch {
+          // Best-effort: ignore if .old cannot be removed.
+        }
+      }
+      if (existsSync(destPath)) {
+        renameSync(destPath, oldPath);
+      }
+      renameSync(tmpPath, destPath);
+    } else {
+      if (existsSync(destPath)) {
+        rmSync(destPath, { force: true });
+      }
+      renameSync(tmpPath, destPath);
+    }
+  } catch (error) {
+    return {
+      error: `Failed to replace ${destPath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+  return {};
+}
+
+export async function upgradeBinary(options: UpgradeBinaryOptions): Promise<UpgradeResult> {
+  const {
+    destPath,
+    currentVersion,
+    version: pinnedVersion,
+    check = false,
+    platform = process.platform,
+    arch = process.arch,
+    pid = process.pid,
+    fetch: fetchFn = globalThis.fetch,
+    getLatest = getLatestVersion,
+    verifyBinary = defaultVerifyBinary,
+  } = options;
+
+  const resolved = await resolveTarget(pinnedVersion, getLatest);
+  if ('error' in resolved) {
+    return errorResult(currentVersion, resolved.error);
+  }
+  const { targetTag, targetVersion, releaseHtmlUrl } = resolved;
+
+  // Fast path: already up-to-date (skipped in check mode so we still report).
+  if (!pinnedVersion && currentVersion === targetVersion && !check) {
+    return {
+      status: 'already-up-to-date',
+      fromVersion: currentVersion,
+      toVersion: targetVersion,
+      ...(releaseHtmlUrl !== undefined && { url: releaseHtmlUrl }),
+    };
+  }
+
+  let assetName: string;
+  try {
+    assetName = computeAssetName(platform, arch);
+  } catch (error) {
+    return errorResult(currentVersion, error instanceof Error ? error.message : String(error), {
+      toVersion: targetVersion,
+    });
+  }
+  const assetUrl = buildAssetUrl(targetTag, assetName);
+
+  if (check) {
+    return {
+      status:
+        currentVersion === targetVersion && !pinnedVersion ? 'already-up-to-date' : 'guidance',
+      fromVersion: currentVersion,
+      toVersion: targetVersion,
+      url: assetUrl,
+    };
+  }
+
+  const tmpPath = `${destPath}.tmp.${pid}`;
+  const dl = await downloadAsset(assetUrl, tmpPath, fetchFn);
+  if (dl.error) {
+    return errorResult(currentVersion, dl.error, { toVersion: targetVersion, url: assetUrl });
+  }
+
+  const verified = await verifyBinary(tmpPath);
+  if (!verified) {
+    return errorResult(
+      currentVersion,
+      `Verification failed: downloaded binary at ${tmpPath} did not report a version. The file has been left in place for inspection.`,
+      { toVersion: targetVersion, url: assetUrl }
+    );
+  }
+
+  const replaced = atomicReplace(tmpPath, destPath, platform);
+  if (replaced.error) {
+    return errorResult(currentVersion, replaced.error, {
+      toVersion: targetVersion,
+      url: assetUrl,
+    });
+  }
+
+  return {
+    status: 'success',
+    fromVersion: currentVersion,
+    toVersion: targetVersion,
+    url: assetUrl,
+    message: verified,
+  };
+}

--- a/src/upgrade/apply-binary.ts
+++ b/src/upgrade/apply-binary.ts
@@ -205,9 +205,8 @@ function atomicReplace(
       }
       renameSync(tmpPath, destPath);
     } else {
-      if (existsSync(destPath)) {
-        rmSync(destPath, { force: true });
-      }
+      // POSIX rename atomically replaces an existing dest: there is never a
+      // moment with no binary on disk, unlike an unlink-then-rename sequence.
       renameSync(tmpPath, destPath);
     }
   } catch (error) {

--- a/src/upgrade/apply-npm.test.ts
+++ b/src/upgrade/apply-npm.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+import { type UpgradeNpmOptions, defaultRunCommand, upgradeNpmGlobal } from './apply-npm.js';
+
+function baseOptions(overrides: Partial<UpgradeNpmOptions> = {}): UpgradeNpmOptions {
+  return {
+    currentVersion: '0.23.1',
+    getLatest: vi.fn(async () => ({
+      checkedAt: '2026-07-12T12:00:00Z',
+      latest: '0.24.0',
+      url: 'https://github.com/ncukondo/search-hub/releases/tag/v0.24.0',
+    })),
+    runCommand: vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' })),
+    ...overrides,
+  };
+}
+
+describe('upgradeNpmGlobal', () => {
+  it('returns guidance with the recommended command when check=true', async () => {
+    const runCommand = vi.fn();
+    const result = await upgradeNpmGlobal(baseOptions({ check: true, runCommand }));
+
+    expect(result.status).toBe('guidance');
+    expect(result.message).toContain('npm i -g @ncukondo/search-hub@latest');
+    expect(result.toVersion).toBe('0.24.0');
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it('returns already-up-to-date when latest equals current version', async () => {
+    const runCommand = vi.fn();
+    const result = await upgradeNpmGlobal(baseOptions({ currentVersion: '0.24.0', runCommand }));
+
+    expect(result.status).toBe('already-up-to-date');
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it('does not run npm without --yes; returns guidance with the command', async () => {
+    const runCommand = vi.fn();
+    const result = await upgradeNpmGlobal(baseOptions({ runCommand }));
+
+    expect(result.status).toBe('guidance');
+    expect(result.message).toContain('npm i -g @ncukondo/search-hub@latest');
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it('runs `npm i -g @ncukondo/search-hub@latest` when yes=true', async () => {
+    const runCommand = vi.fn(async (_command: string, _args: string[]) => ({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    }));
+    const result = await upgradeNpmGlobal(baseOptions({ yes: true, runCommand }));
+
+    expect(runCommand).toHaveBeenCalledTimes(1);
+    const [command, args] = runCommand.mock.calls[0] ?? [];
+    expect(command).toBe('npm');
+    expect(args).toEqual(['i', '-g', '@ncukondo/search-hub@latest']);
+    expect(result.status).toBe('success');
+    expect(result.toVersion).toBe('0.24.0');
+  });
+
+  it('pins to the explicit tag when --version is provided and yes=true', async () => {
+    const runCommand = vi.fn(async (_command: string, _args: string[]) => ({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    }));
+    await upgradeNpmGlobal(baseOptions({ yes: true, version: 'v0.25.0', runCommand }));
+
+    const [, args] = runCommand.mock.calls[0] ?? [];
+    expect(args).toEqual(['i', '-g', '@ncukondo/search-hub@0.25.0']);
+  });
+
+  it('surfaces a non-zero npm exit code as an error result', async () => {
+    const runCommand = vi.fn(async () => ({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'npm ERR! permission denied',
+    }));
+    const result = await upgradeNpmGlobal(baseOptions({ yes: true, runCommand }));
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/permission denied|exit.*1/i);
+  });
+
+  it('returns error when getLatest resolves to null and no version pinned', async () => {
+    const result = await upgradeNpmGlobal(baseOptions({ getLatest: vi.fn(async () => null) }));
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/latest/i);
+  });
+
+  it('bypasses getLatest when --version is pinned', async () => {
+    const getLatest = vi.fn();
+    const result = await upgradeNpmGlobal(
+      baseOptions({ check: true, version: 'v0.25.0', getLatest })
+    );
+
+    expect(result.status).toBe('guidance');
+    expect(result.message).toContain('@0.25.0');
+    expect(result.toVersion).toBe('0.25.0');
+    expect(getLatest).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a friendly message when npm is not on PATH (ENOENT)', async () => {
+    const runCommand = vi.fn(async () =>
+      defaultRunCommand('search-hub-nonexistent-binary-for-test-xyz', ['--version'])
+    );
+    const result = await upgradeNpmGlobal(baseOptions({ yes: true, runCommand }));
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/not found in PATH/);
+    expect(result.error).not.toMatch(/spawn ENOENT/);
+  });
+});
+
+describe('defaultRunCommand', () => {
+  it('returns a friendly ENOENT message when the command is missing', async () => {
+    const result = await defaultRunCommand('search-hub-nonexistent-binary-for-test-xyz', [
+      '--version',
+    ]);
+
+    expect(result.exitCode).toBe(127);
+    expect(result.stderr).toContain('not found in PATH');
+    expect(result.stderr).not.toContain('spawn ENOENT');
+  });
+});

--- a/src/upgrade/apply-npm.ts
+++ b/src/upgrade/apply-npm.ts
@@ -1,0 +1,137 @@
+/**
+ * npm-global upgrade strategy.
+ *
+ * Without `--yes`: prints the exact `npm i -g …` command and exits without
+ * mutating anything. With `--yes`: runs the command directly.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { UpgradeResult } from './apply-binary.js';
+import { type ReleaseInfo, getLatestVersion } from './check.js';
+
+const execFileAsync = promisify(execFile);
+
+const PACKAGE_NAME = '@ncukondo/search-hub';
+
+export interface RunCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface UpgradeNpmOptions {
+  currentVersion: string;
+  /** Explicit tag like "v0.24.0" or "0.24.0". Defaults to the getLatest result. */
+  version?: string;
+  /** `--check`: report only, no action. */
+  check?: boolean;
+  /** `--yes`: run npm instead of printing the command. */
+  yes?: boolean;
+  /** Injection points. */
+  getLatest?: () => Promise<ReleaseInfo | null>;
+  runCommand?: (command: string, args: string[]) => Promise<RunCommandResult>;
+}
+
+export type { UpgradeResult };
+
+function stripV(tag: string): string {
+  return tag.startsWith('v') ? tag.slice(1) : tag;
+}
+
+export async function defaultRunCommand(
+  command: string,
+  args: string[]
+): Promise<RunCommandResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync(command, args, { encoding: 'utf-8' });
+    return { exitCode: 0, stdout, stderr };
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException & {
+      code?: number | string;
+      stdout?: string;
+      stderr?: string;
+    };
+    if (err.code === 'ENOENT') {
+      return {
+        exitCode: 127,
+        stdout: '',
+        stderr: `${command} not found in PATH — install Node.js to use the npm-global upgrade path`,
+      };
+    }
+    const exitCode = typeof err.code === 'number' ? err.code : 1;
+    return {
+      exitCode,
+      stdout: err.stdout ?? '',
+      stderr: err.stderr ?? err.message ?? '',
+    };
+  }
+}
+
+export async function upgradeNpmGlobal(options: UpgradeNpmOptions): Promise<UpgradeResult> {
+  const {
+    currentVersion,
+    version: pinnedVersion,
+    check = false,
+    yes = false,
+    getLatest = getLatestVersion,
+    runCommand = defaultRunCommand,
+  } = options;
+
+  let targetVersion: string;
+  let specifier: string;
+  if (pinnedVersion) {
+    targetVersion = stripV(pinnedVersion);
+    specifier = targetVersion;
+  } else {
+    const release = await getLatest();
+    if (!release) {
+      return {
+        status: 'error',
+        fromVersion: currentVersion,
+        error: 'Could not determine the latest release. Check your network connection.',
+      };
+    }
+    targetVersion = stripV(release.latest);
+    specifier = 'latest';
+  }
+
+  const commandArgs = ['i', '-g', `${PACKAGE_NAME}@${specifier}`];
+  const commandLine = `npm ${commandArgs.join(' ')}`;
+
+  if (!pinnedVersion && currentVersion === targetVersion && !check) {
+    return {
+      status: 'already-up-to-date',
+      fromVersion: currentVersion,
+      toVersion: targetVersion,
+      message: commandLine,
+    };
+  }
+
+  if (check || !yes) {
+    return {
+      status: 'guidance',
+      fromVersion: currentVersion,
+      toVersion: targetVersion,
+      message: commandLine,
+    };
+  }
+
+  const result = await runCommand('npm', commandArgs);
+  if (result.exitCode !== 0) {
+    const details = result.stderr.trim() || result.stdout.trim();
+    return {
+      status: 'error',
+      fromVersion: currentVersion,
+      toVersion: targetVersion,
+      message: commandLine,
+      error: `npm exited with code ${result.exitCode}${details ? `: ${details}` : ''}`,
+    };
+  }
+
+  return {
+    status: 'success',
+    fromVersion: currentVersion,
+    toVersion: targetVersion,
+    message: commandLine,
+  };
+}

--- a/src/upgrade/check.test.ts
+++ b/src/upgrade/check.test.ts
@@ -1,0 +1,322 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getLatestVersion } from './check.js';
+
+function makeFetchOk(tag: string, url: string): typeof globalThis.fetch {
+  return vi.fn(
+    async () =>
+      new Response(JSON.stringify({ tag_name: tag, html_url: url }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+  ) as unknown as typeof globalThis.fetch;
+}
+
+function makeFetchStatus(status: number): typeof globalThis.fetch {
+  return vi.fn(
+    async () =>
+      new Response('rate limit', {
+        status,
+        headers: { 'content-type': 'text/plain' },
+      })
+  ) as unknown as typeof globalThis.fetch;
+}
+
+function makeFetchThrow(): typeof globalThis.fetch {
+  return vi.fn(async () => {
+    throw new Error('network down');
+  }) as unknown as typeof globalThis.fetch;
+}
+
+describe('getLatestVersion', () => {
+  let testDir: string;
+  let cachePath: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `upgrade-check-test-${randomUUID()}`);
+    mkdirSync(testDir, { recursive: true });
+    cachePath = join(testDir, 'update-check.json');
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns cached value without HTTP when cache is fresh (< 24h)', async () => {
+    const now = new Date('2026-07-12T12:00:00Z');
+    const checkedAt = new Date(now.getTime() - 60 * 60 * 1000).toISOString();
+    writeFileSync(
+      cachePath,
+      JSON.stringify({
+        checkedAt,
+        latest: '0.24.0',
+        url: 'https://github.com/ncukondo/search-hub/releases/tag/v0.24.0',
+      })
+    );
+    const fetchFn = vi.fn();
+
+    const result = await getLatestVersion({
+      cachePath,
+      fetch: fetchFn as unknown as typeof globalThis.fetch,
+      now: () => now,
+    });
+
+    expect(result).toEqual({
+      checkedAt,
+      latest: '0.24.0',
+      url: 'https://github.com/ncukondo/search-hub/releases/tag/v0.24.0',
+    });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('triggers HTTP fetch and writes cache when cache is stale (> 24h)', async () => {
+    const now = new Date('2026-07-12T12:00:00Z');
+    const checkedAt = new Date(now.getTime() - 25 * 60 * 60 * 1000).toISOString();
+    writeFileSync(
+      cachePath,
+      JSON.stringify({
+        checkedAt,
+        latest: '0.23.0',
+        url: 'https://example.com/old',
+      })
+    );
+    const fetchFn = makeFetchOk(
+      'v0.24.0',
+      'https://github.com/ncukondo/search-hub/releases/tag/v0.24.0'
+    );
+
+    const result = await getLatestVersion({
+      cachePath,
+      fetch: fetchFn,
+      now: () => now,
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(result?.latest).toBe('0.24.0');
+    expect(result?.url).toBe('https://github.com/ncukondo/search-hub/releases/tag/v0.24.0');
+    expect(result?.checkedAt).toBe(now.toISOString());
+
+    const cached = JSON.parse(readFileSync(cachePath, 'utf-8'));
+    expect(cached.latest).toBe('0.24.0');
+    expect(cached.checkedAt).toBe(now.toISOString());
+  });
+
+  it('triggers HTTP fetch and writes cache when no cache exists', async () => {
+    const now = new Date('2026-07-12T12:00:00Z');
+    const fetchFn = makeFetchOk(
+      'v1.0.0',
+      'https://github.com/ncukondo/search-hub/releases/tag/v1.0.0'
+    );
+
+    const result = await getLatestVersion({
+      cachePath,
+      fetch: fetchFn,
+      now: () => now,
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(result?.latest).toBe('1.0.0');
+    expect(existsSync(cachePath)).toBe(true);
+    const cached = JSON.parse(readFileSync(cachePath, 'utf-8'));
+    expect(cached.latest).toBe('1.0.0');
+  });
+
+  it('creates missing parent directories for the cache file', async () => {
+    const nestedCachePath = join(testDir, 'data', 'search-hub', 'update-check.json');
+    const now = new Date('2026-07-12T12:00:00Z');
+    const fetchFn = makeFetchOk(
+      'v1.0.0',
+      'https://github.com/ncukondo/search-hub/releases/tag/v1.0.0'
+    );
+
+    const result = await getLatestVersion({
+      cachePath: nestedCachePath,
+      fetch: fetchFn,
+      now: () => now,
+    });
+
+    expect(result?.latest).toBe('1.0.0');
+    expect(existsSync(nestedCachePath)).toBe(true);
+  });
+
+  it('sends the search-hub user-agent and GitHub accept header', async () => {
+    const now = new Date('2026-07-12T12:00:00Z');
+    const fetchFn = makeFetchOk(
+      'v1.0.0',
+      'https://github.com/ncukondo/search-hub/releases/tag/v1.0.0'
+    );
+
+    await getLatestVersion({ cachePath, fetch: fetchFn, now: () => now });
+
+    const mock = fetchFn as unknown as ReturnType<typeof vi.fn>;
+    const [url, init] = mock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.github.com/repos/ncukondo/search-hub/releases/latest');
+    expect(init.headers).toMatchObject({
+      accept: 'application/vnd.github+json',
+      'user-agent': 'search-hub-update-check',
+    });
+  });
+
+  it('force=true bypasses fresh cache and re-fetches', async () => {
+    const now = new Date('2026-07-12T12:00:00Z');
+    const checkedAt = new Date(now.getTime() - 60 * 60 * 1000).toISOString();
+    writeFileSync(
+      cachePath,
+      JSON.stringify({
+        checkedAt,
+        latest: '0.23.0',
+        url: 'https://example.com/old',
+      })
+    );
+    const fetchFn = makeFetchOk(
+      'v0.24.0',
+      'https://github.com/ncukondo/search-hub/releases/tag/v0.24.0'
+    );
+
+    const result = await getLatestVersion({
+      cachePath,
+      fetch: fetchFn,
+      now: () => now,
+      force: true,
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(result?.latest).toBe('0.24.0');
+  });
+
+  it('returns null and does not write cache on network failure', async () => {
+    const now = new Date('2026-07-12T12:00:00Z');
+    const fetchFn = makeFetchThrow();
+
+    const result = await getLatestVersion({
+      cachePath,
+      fetch: fetchFn,
+      now: () => now,
+    });
+
+    expect(result).toBeNull();
+    expect(existsSync(cachePath)).toBe(false);
+  });
+
+  it('falls back to existing cache on GitHub 403 (rate limit)', async () => {
+    const now = new Date('2026-07-12T12:00:00Z');
+    const checkedAt = new Date(now.getTime() - 25 * 60 * 60 * 1000).toISOString();
+    const existingCache = {
+      checkedAt,
+      latest: '0.23.0',
+      url: 'https://example.com/old',
+    };
+    writeFileSync(cachePath, JSON.stringify(existingCache));
+    const fetchFn = makeFetchStatus(403);
+
+    const result = await getLatestVersion({
+      cachePath,
+      fetch: fetchFn,
+      now: () => now,
+    });
+
+    expect(result).toEqual(existingCache);
+    const cached = JSON.parse(readFileSync(cachePath, 'utf-8'));
+    expect(cached).toEqual(existingCache);
+  });
+
+  it('returns null on GitHub 403 (rate limit) when no cache exists', async () => {
+    const now = new Date('2026-07-12T12:00:00Z');
+    const fetchFn = makeFetchStatus(403);
+
+    const result = await getLatestVersion({
+      cachePath,
+      fetch: fetchFn,
+      now: () => now,
+    });
+
+    expect(result).toBeNull();
+    expect(existsSync(cachePath)).toBe(false);
+  });
+
+  it('falls back to existing cache on GitHub 429 (secondary rate limit)', async () => {
+    const now = new Date('2026-07-12T12:00:00Z');
+    const checkedAt = new Date(now.getTime() - 25 * 60 * 60 * 1000).toISOString();
+    const existingCache = {
+      checkedAt,
+      latest: '0.23.0',
+      url: 'https://example.com/old',
+    };
+    writeFileSync(cachePath, JSON.stringify(existingCache));
+    const fetchFn = makeFetchStatus(429);
+
+    const result = await getLatestVersion({
+      cachePath,
+      fetch: fetchFn,
+      now: () => now,
+    });
+
+    expect(result).toEqual(existingCache);
+  });
+
+  it("strips a leading 'v' from tag_name", async () => {
+    const now = new Date('2026-07-12T12:00:00Z');
+    const fetchFn = makeFetchOk(
+      'v2.5.1',
+      'https://github.com/ncukondo/search-hub/releases/tag/v2.5.1'
+    );
+
+    const result = await getLatestVersion({ cachePath, fetch: fetchFn, now: () => now });
+
+    expect(result?.latest).toBe('2.5.1');
+  });
+
+  it("accepts tag_name without leading 'v'", async () => {
+    const now = new Date('2026-07-12T12:00:00Z');
+    const fetchFn = makeFetchOk(
+      '2.5.1',
+      'https://github.com/ncukondo/search-hub/releases/tag/2.5.1'
+    );
+
+    const result = await getLatestVersion({ cachePath, fetch: fetchFn, now: () => now });
+
+    expect(result?.latest).toBe('2.5.1');
+  });
+
+  it('returns null and preserves cache when fetched JSON is malformed', async () => {
+    const now = new Date('2026-07-12T12:00:00Z');
+    const existingCache = {
+      checkedAt: new Date(now.getTime() - 25 * 60 * 60 * 1000).toISOString(),
+      latest: '0.23.0',
+      url: 'https://example.com/old',
+    };
+    writeFileSync(cachePath, JSON.stringify(existingCache));
+    const fetchFn = vi.fn(
+      async () =>
+        new Response('not json at all', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+    ) as unknown as typeof globalThis.fetch;
+
+    const result = await getLatestVersion({ cachePath, fetch: fetchFn, now: () => now });
+
+    expect(result).toBeNull();
+    const cached = JSON.parse(readFileSync(cachePath, 'utf-8'));
+    expect(cached).toEqual(existingCache);
+  });
+
+  it('ignores corrupt cache file and re-fetches', async () => {
+    const now = new Date('2026-07-12T12:00:00Z');
+    writeFileSync(cachePath, '{not valid json');
+    const fetchFn = makeFetchOk(
+      'v0.24.0',
+      'https://github.com/ncukondo/search-hub/releases/tag/v0.24.0'
+    );
+
+    const result = await getLatestVersion({ cachePath, fetch: fetchFn, now: () => now });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(result?.latest).toBe('0.24.0');
+  });
+});

--- a/src/upgrade/check.test.ts
+++ b/src/upgrade/check.test.ts
@@ -306,6 +306,57 @@ describe('getLatestVersion', () => {
     expect(cached).toEqual(existingCache);
   });
 
+  it('passes an AbortSignal to fetch when timeoutMs is set', async () => {
+    const now = new Date('2026-07-12T12:00:00Z');
+    const fetchFn = makeFetchOk(
+      'v0.24.0',
+      'https://github.com/ncukondo/search-hub/releases/tag/v0.24.0'
+    );
+
+    await getLatestVersion({ cachePath, fetch: fetchFn, now: () => now, timeoutMs: 3000 });
+
+    const mock = fetchFn as unknown as ReturnType<typeof vi.fn>;
+    const [, init] = mock.mock.calls[0] as [string, RequestInit];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('does not pass an AbortSignal when timeoutMs is unset', async () => {
+    const now = new Date('2026-07-12T12:00:00Z');
+    const fetchFn = makeFetchOk(
+      'v0.24.0',
+      'https://github.com/ncukondo/search-hub/releases/tag/v0.24.0'
+    );
+
+    await getLatestVersion({ cachePath, fetch: fetchFn, now: () => now });
+
+    const mock = fetchFn as unknown as ReturnType<typeof vi.fn>;
+    const [, init] = mock.mock.calls[0] as [string, RequestInit];
+    expect(init.signal).toBeUndefined();
+  });
+
+  it('returns null when the fetch hangs past timeoutMs instead of waiting forever', async () => {
+    const now = new Date('2026-07-12T12:00:00Z');
+    // A fetch that never resolves on its own; it only rejects when aborted.
+    const fetchFn = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('This operation was aborted', 'AbortError'));
+          });
+        })
+    ) as unknown as typeof globalThis.fetch;
+
+    const result = await getLatestVersion({
+      cachePath,
+      fetch: fetchFn,
+      now: () => now,
+      timeoutMs: 50,
+    });
+
+    expect(result).toBeNull();
+    expect(existsSync(cachePath)).toBe(false);
+  });
+
   it('ignores corrupt cache file and re-fetches', async () => {
     const now = new Date('2026-07-12T12:00:00Z');
     writeFileSync(cachePath, '{not valid json');

--- a/src/upgrade/check.ts
+++ b/src/upgrade/check.ts
@@ -1,0 +1,137 @@
+/**
+ * Update-check cache + GitHub Releases API client.
+ *
+ * Fetches the latest release tag from GitHub and caches the result for
+ * 24 hours at `{data}/update-check.json` (search-hub's platform data dir).
+ * Network/parse failures are swallowed (returns null) so the caller can
+ * ignore them silently.
+ */
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { getDataDir } from '../config/paths.js';
+
+export interface ReleaseInfo {
+  checkedAt: string;
+  latest: string;
+  url: string;
+}
+
+export interface GetLatestVersionOptions {
+  force?: boolean;
+  cachePath?: string;
+  fetch?: typeof globalThis.fetch;
+  now?: () => Date;
+  ttlMs?: number;
+}
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+const RELEASES_API_URL = 'https://api.github.com/repos/ncukondo/search-hub/releases/latest';
+
+function defaultCachePath(): string {
+  return join(getDataDir(), 'update-check.json');
+}
+
+function normalizeTag(tag: string): string {
+  return tag.startsWith('v') ? tag.slice(1) : tag;
+}
+
+/** Write via a temp file + rename so a concurrent reader never sees a torn cache. */
+async function writeFileAtomic(filePath: string, content: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp.${process.pid}`;
+  await writeFile(tmpPath, content, 'utf-8');
+  await rename(tmpPath, filePath);
+}
+
+async function readCache(cachePath: string): Promise<ReleaseInfo | null> {
+  try {
+    const text = await readFile(cachePath, 'utf-8');
+    const parsed = JSON.parse(text) as Partial<ReleaseInfo>;
+    if (
+      typeof parsed.checkedAt === 'string' &&
+      typeof parsed.latest === 'string' &&
+      typeof parsed.url === 'string'
+    ) {
+      return { checkedAt: parsed.checkedAt, latest: parsed.latest, url: parsed.url };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function isFresh(cache: ReleaseInfo, now: Date, ttlMs: number): boolean {
+  const checkedAt = Date.parse(cache.checkedAt);
+  if (Number.isNaN(checkedAt)) return false;
+  return now.getTime() - checkedAt < ttlMs;
+}
+
+interface ReleaseApiResponse {
+  tag_name?: unknown;
+  html_url?: unknown;
+}
+
+export async function getLatestVersion(
+  options: GetLatestVersionOptions = {}
+): Promise<ReleaseInfo | null> {
+  const {
+    force = false,
+    cachePath = defaultCachePath(),
+    fetch: fetchFn = globalThis.fetch,
+    now = () => new Date(),
+    ttlMs = DEFAULT_TTL_MS,
+  } = options;
+
+  const currentTime = now();
+  const cached = await readCache(cachePath);
+
+  if (!force && cached && isFresh(cached, currentTime, ttlMs)) {
+    return cached;
+  }
+
+  let response: Response;
+  try {
+    response = await fetchFn(RELEASES_API_URL, {
+      headers: {
+        accept: 'application/vnd.github+json',
+        'user-agent': 'search-hub-update-check',
+      },
+    });
+  } catch {
+    return null;
+  }
+
+  // On rate-limit (403/429), fall back to any existing cache per spec.
+  if (response.status === 403 || response.status === 429) {
+    return cached ?? null;
+  }
+
+  if (!response.ok) {
+    return null;
+  }
+
+  let payload: ReleaseApiResponse;
+  try {
+    payload = (await response.json()) as ReleaseApiResponse;
+  } catch {
+    return null;
+  }
+
+  if (typeof payload.tag_name !== 'string' || typeof payload.html_url !== 'string') {
+    return null;
+  }
+
+  const info: ReleaseInfo = {
+    checkedAt: currentTime.toISOString(),
+    latest: normalizeTag(payload.tag_name),
+    url: payload.html_url,
+  };
+
+  try {
+    await writeFileAtomic(cachePath, `${JSON.stringify(info, null, 2)}\n`);
+  } catch {
+    // Cache write failure should not affect the returned value.
+  }
+
+  return info;
+}

--- a/src/upgrade/check.ts
+++ b/src/upgrade/check.ts
@@ -22,6 +22,13 @@ export interface GetLatestVersionOptions {
   fetch?: typeof globalThis.fetch;
   now?: () => Date;
   ttlMs?: number;
+  /**
+   * Abort the HTTP request after this many milliseconds. Unset means no
+   * timeout (the interactive `upgrade` command can afford to wait); the
+   * notifier passes a short timeout so a hung connection never keeps the
+   * process alive after the user's command has finished.
+   */
+  timeoutMs?: number;
 }
 
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
@@ -80,6 +87,7 @@ export async function getLatestVersion(
     fetch: fetchFn = globalThis.fetch,
     now = () => new Date(),
     ttlMs = DEFAULT_TTL_MS,
+    timeoutMs,
   } = options;
 
   const currentTime = now();
@@ -96,6 +104,7 @@ export async function getLatestVersion(
         accept: 'application/vnd.github+json',
         'user-agent': 'search-hub-update-check',
       },
+      ...(timeoutMs !== undefined && { signal: AbortSignal.timeout(timeoutMs) }),
     });
   } catch {
     return null;

--- a/src/upgrade/detect.test.ts
+++ b/src/upgrade/detect.test.ts
@@ -1,0 +1,201 @@
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { detectInstallMethod, isBunVirtualPath, resolveInvocationPath } from './detect.js';
+
+describe('detectInstallMethod', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `upgrade-detect-test-${randomUUID()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it("returns 'binary' for a plain path under ~/.local/bin/search-hub (no node_modules/)", () => {
+    const binDir = join(testDir, 'home', 'user', '.local', 'bin');
+    mkdirSync(binDir, { recursive: true });
+    const binPath = join(binDir, 'search-hub');
+    writeFileSync(binPath, '#!/bin/sh\n');
+
+    expect(detectInstallMethod(binPath)).toBe('binary');
+  });
+
+  it("returns 'npm-global' for a path containing node_modules/", () => {
+    const binPath = join(
+      testDir,
+      'usr',
+      'lib',
+      'node_modules',
+      '@ncukondo',
+      'search-hub',
+      'dist',
+      'cli',
+      'index.js'
+    );
+    mkdirSync(
+      join(testDir, 'usr', 'lib', 'node_modules', '@ncukondo', 'search-hub', 'dist', 'cli'),
+      { recursive: true }
+    );
+    writeFileSync(binPath, '#!/usr/bin/env node\n');
+
+    expect(detectInstallMethod(binPath)).toBe('npm-global');
+  });
+
+  it("returns 'dev' for a symlink that resolves into a git worktree", () => {
+    const repoDir = join(testDir, 'repo');
+    mkdirSync(join(repoDir, '.git'), { recursive: true });
+    mkdirSync(join(repoDir, 'bin'), { recursive: true });
+    writeFileSync(join(repoDir, 'package.json'), '{"name":"search-hub"}\n');
+    const realCli = join(repoDir, 'bin', 'cli.js');
+    writeFileSync(realCli, '#!/usr/bin/env node\n');
+
+    // NOTE: linkDir deliberately avoids `.local/bin/` / `/usr/local/bin/` so
+    // the typical-binary-path fast path doesn't short-circuit this case.
+    const linkDir = join(testDir, 'home', 'user', 'custom', 'bin');
+    mkdirSync(linkDir, { recursive: true });
+    const linkPath = join(linkDir, 'search-hub');
+    symlinkSync(realCli, linkPath);
+
+    expect(detectInstallMethod(linkPath)).toBe('dev');
+  });
+
+  it("returns 'npx' for a path under a typical npm cache (~/.npm/_npx/)", () => {
+    const npxDir = join(
+      testDir,
+      'home',
+      'user',
+      '.npm',
+      '_npx',
+      'abc123',
+      'node_modules',
+      '@ncukondo',
+      'search-hub',
+      'dist',
+      'cli'
+    );
+    mkdirSync(npxDir, { recursive: true });
+    const npxPath = join(npxDir, 'index.js');
+    writeFileSync(npxPath, '#!/usr/bin/env node\n');
+
+    expect(detectInstallMethod(npxPath)).toBe('npx');
+  });
+
+  it("returns 'dev' even when the symlink target is also under node_modules (npm link)", () => {
+    // npm link creates a symlink in a global node_modules pointing back into the source repo.
+    const repoDir = join(testDir, 'src-repo');
+    mkdirSync(join(repoDir, '.git'), { recursive: true });
+    mkdirSync(join(repoDir, 'bin'), { recursive: true });
+    writeFileSync(join(repoDir, 'package.json'), '{"name":"search-hub"}\n');
+    const realCli = join(repoDir, 'bin', 'cli.js');
+    writeFileSync(realCli, '#!/usr/bin/env node\n');
+
+    const globalNm = join(testDir, 'global', 'lib', 'node_modules', '@ncukondo');
+    mkdirSync(globalNm, { recursive: true });
+    const linkedPkg = join(globalNm, 'search-hub');
+    symlinkSync(repoDir, linkedPkg);
+    const linkPath = join(linkedPkg, 'bin', 'cli.js');
+
+    expect(detectInstallMethod(linkPath)).toBe('dev');
+  });
+
+  it("returns 'binary' when a dotfiles repo in $HOME has .git but the binary lives in ~/.local/bin", () => {
+    // Regression: a user who manages $HOME as a git repo (dotfiles) should not
+    // have `~/.local/bin/search-hub` misdetected as a dev checkout.
+    const home = join(testDir, 'home', 'user');
+    mkdirSync(join(home, '.git'), { recursive: true });
+    // Intentionally no package.json at $HOME so it's not a search-hub checkout.
+    const binDir = join(home, '.local', 'bin');
+    mkdirSync(binDir, { recursive: true });
+    const binPath = join(binDir, 'search-hub');
+    writeFileSync(binPath, '#!/bin/sh\n');
+
+    expect(detectInstallMethod(binPath)).toBe('binary');
+  });
+
+  it("returns 'binary' even if an ancestor dotfiles repo has package.json (typical binary path wins)", () => {
+    const home = join(testDir, 'home', 'user');
+    mkdirSync(join(home, '.git'), { recursive: true });
+    writeFileSync(join(home, 'package.json'), '{"name":"dotfiles"}\n');
+    const binDir = join(home, '.local', 'bin');
+    mkdirSync(binDir, { recursive: true });
+    const binPath = join(binDir, 'search-hub');
+    writeFileSync(binPath, '#!/bin/sh\n');
+
+    expect(detectInstallMethod(binPath)).toBe('binary');
+  });
+
+  it('falls back to process.argv[1] when argv1 is omitted', () => {
+    // We don't assert a specific value (depends on the test runner path), just
+    // that the function executes and returns one of the valid enum values.
+    const method = detectInstallMethod();
+    expect(['binary', 'npm-global', 'dev', 'npx']).toContain(method);
+  });
+
+  it("returns 'binary' when the path does not exist (best-effort fallback)", () => {
+    const nonexistent = join(testDir, 'no-such', 'search-hub');
+    expect(detectInstallMethod(nonexistent)).toBe('binary');
+  });
+
+  it("resolves via execPath when argv1 is a Bun virtual path (compiled binary in ~/.local/bin)", () => {
+    // In a Bun-compiled binary, process.argv[1] is a virtual bunfs path; the
+    // real on-disk location is process.execPath.
+    const binDir = join(testDir, 'home', 'user', '.local', 'bin');
+    mkdirSync(binDir, { recursive: true });
+    const execPath = join(binDir, 'search-hub');
+    writeFileSync(execPath, 'binary\n');
+
+    expect(detectInstallMethod('/$bunfs/root/search-hub', execPath)).toBe('binary');
+  });
+
+  it("returns 'dev' when argv1 is a Bun virtual path and execPath is inside a repo checkout", () => {
+    const repoDir = join(testDir, 'repo');
+    mkdirSync(join(repoDir, '.git'), { recursive: true });
+    mkdirSync(join(repoDir, 'dist'), { recursive: true });
+    writeFileSync(join(repoDir, 'package.json'), '{"name":"search-hub"}\n');
+    const execPath = join(repoDir, 'dist', 'search-hub-linux-x64');
+    writeFileSync(execPath, 'binary\n');
+
+    expect(detectInstallMethod('/$bunfs/root/search-hub', execPath)).toBe('dev');
+  });
+});
+
+describe('isBunVirtualPath', () => {
+  it('detects the unix bunfs virtual root', () => {
+    expect(isBunVirtualPath('/$bunfs/root/search-hub')).toBe(true);
+  });
+
+  it('detects the windows bunfs virtual root', () => {
+    expect(isBunVirtualPath('B:\\~BUN\\root\\search-hub.exe')).toBe(true);
+  });
+
+  it('does not flag regular paths', () => {
+    expect(isBunVirtualPath('/home/user/.local/bin/search-hub')).toBe(false);
+    expect(isBunVirtualPath('C:\\Users\\user\\bin\\search-hub.exe')).toBe(false);
+  });
+});
+
+describe('resolveInvocationPath', () => {
+  it('returns argv1 for a regular node invocation', () => {
+    expect(resolveInvocationPath('/usr/lib/node_modules/x/cli.js', '/usr/bin/node')).toBe(
+      '/usr/lib/node_modules/x/cli.js'
+    );
+  });
+
+  it('returns execPath when argv1 is a Bun virtual path', () => {
+    expect(resolveInvocationPath('/$bunfs/root/search-hub', '/home/u/.local/bin/search-hub')).toBe(
+      '/home/u/.local/bin/search-hub'
+    );
+  });
+
+  it('returns execPath when argv1 is empty (no script argument)', () => {
+    expect(resolveInvocationPath('', '/home/u/.local/bin/search-hub')).toBe(
+      '/home/u/.local/bin/search-hub'
+    );
+  });
+});

--- a/src/upgrade/detect.ts
+++ b/src/upgrade/detect.ts
@@ -1,0 +1,113 @@
+/**
+ * Install-method detection for `search-hub upgrade`.
+ *
+ * Resolves the invocation path (normally `process.argv[1]`) through
+ * `realpathSync` and pattern-matches the resolved path to determine how the
+ * user installed search-hub.
+ *
+ * Bun-compiled binaries (`bun build --compile`, entry `src/cli/entry-bun.ts`)
+ * are a special case: `process.argv[1]` is a virtual bunfs path
+ * (`/$bunfs/root/...` on Unix, `B:\~BUN\root\...` on Windows) that does not
+ * exist on disk and cannot be resolved with `realpathSync`. In that case the
+ * real on-disk location of the running executable is `process.execPath`, so
+ * detection falls back to it (see {@link resolveInvocationPath}).
+ */
+import { existsSync, realpathSync, statSync } from 'node:fs';
+import { dirname, sep } from 'node:path';
+
+export type InstallMethod = 'binary' | 'npm-global' | 'dev' | 'npx';
+
+/**
+ * Typical install locations for the single-binary `search-hub`. Matched as an
+ * embedded path chain so a resolved path like `/home/user/.local/bin/search-hub`
+ * wins over a `.git` directory in an ancestor (e.g. a dotfiles repo at $HOME).
+ */
+const BINARY_PATH_CHAINS: readonly string[][] = [
+  ['.local', 'bin'],
+  ['usr', 'local', 'bin'],
+  ['opt', 'homebrew', 'bin'],
+  ['opt', 'local', 'bin'],
+];
+
+/**
+ * True when `path` is a virtual path inside a Bun-compiled executable's
+ * embedded filesystem. Verified against Bun 1.x behavior: `process.argv[1]`
+ * is `/$bunfs/root/<outfile>` on Unix and `B:\~BUN\root\<outfile>.exe` on
+ * Windows, while `process.execPath` points at the real compiled binary.
+ */
+export function isBunVirtualPath(path: string): boolean {
+  return path.startsWith('/$bunfs/') || /^[A-Za-z]:\\~BUN\\/.test(path) || path.includes('/~BUN/');
+}
+
+/**
+ * Resolve the effective on-disk invocation path: `argv1` for regular node
+ * invocations, `execPath` when running inside a Bun-compiled binary (where
+ * `argv1` is a virtual bunfs path) or when `argv1` is missing.
+ */
+export function resolveInvocationPath(
+  argv1: string | undefined = process.argv[1],
+  execPath: string = process.execPath
+): string {
+  if (!argv1 || isBunVirtualPath(argv1)) return execPath;
+  return argv1;
+}
+
+function safeRealpath(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
+function containsSegment(path: string, segment: string): boolean {
+  const wrapped = `${sep}${segment}${sep}`;
+  return path.includes(wrapped) || path.endsWith(`${sep}${segment}`);
+}
+
+function containsPathChain(path: string, chain: readonly string[]): boolean {
+  const wrapped = `${sep}${chain.join(sep)}${sep}`;
+  return path.includes(wrapped);
+}
+
+function isTypicalBinaryPath(path: string): boolean {
+  return BINARY_PATH_CHAINS.some((chain) => containsPathChain(path, chain));
+}
+
+/**
+ * True only when `startPath` is inside a git worktree that looks like a
+ * search-hub checkout (i.e. the repo root contains `package.json`).
+ *
+ * The `package.json` check avoids false positives for unrelated ancestor
+ * repos — e.g. a dotfiles repo at $HOME picking up a plain binary installed
+ * at `~/.local/bin/search-hub`.
+ */
+function isInsideGitWorktree(startPath: string): boolean {
+  let current: string;
+  try {
+    current = statSync(startPath).isDirectory() ? startPath : dirname(startPath);
+  } catch {
+    current = dirname(startPath);
+  }
+  while (true) {
+    if (existsSync(`${current}${sep}.git`)) {
+      return existsSync(`${current}${sep}package.json`);
+    }
+    const parent = dirname(current);
+    if (parent === current) return false;
+    current = parent;
+  }
+}
+
+export function detectInstallMethod(argv1?: string, execPath?: string): InstallMethod {
+  const source = resolveInvocationPath(argv1, execPath ?? process.execPath);
+  if (!source) return 'binary';
+
+  const resolved = safeRealpath(source);
+
+  if (containsSegment(resolved, '_npx')) return 'npx';
+  if (isTypicalBinaryPath(resolved)) return 'binary';
+  if (isInsideGitWorktree(resolved)) return 'dev';
+  if (containsSegment(resolved, 'node_modules')) return 'npm-global';
+  return 'binary';
+}

--- a/src/upgrade/notifier.test.ts
+++ b/src/upgrade/notifier.test.ts
@@ -85,6 +85,47 @@ describe('notifier', () => {
     expect(output()).toBe('');
   });
 
+  it('does not start a check when quiet=true (global --quiet flag)', async () => {
+    const { maybeStartUpdateCheck, flushUpdateNotice } = await freshNotifier();
+    const getLatest = vi.fn(async () => release('0.24.0'));
+    const { stream, output } = captureStream();
+
+    await maybeStartUpdateCheck('status', {
+      isTty: true,
+      env: {},
+      currentVersion: '0.23.1',
+      getLatest,
+      output: stream,
+      quiet: true,
+    });
+
+    expect(getLatest).not.toHaveBeenCalled();
+    flushUpdateNotice();
+    expect(output()).toBe('');
+  });
+
+  it('applies a 3s timeout to the default version check', async () => {
+    vi.doMock('./check.js', () => ({
+      getLatestVersion: vi.fn(async () => null),
+    }));
+    try {
+      const notifier = await import('./notifier.js');
+      const check = await import('./check.js');
+      const { stream } = captureStream();
+
+      await notifier.maybeStartUpdateCheck('status', {
+        isTty: true,
+        env: {},
+        currentVersion: '0.23.1',
+        output: stream,
+      });
+
+      expect(check.getLatestVersion).toHaveBeenCalledWith({ timeoutMs: 3000 });
+    } finally {
+      vi.doUnmock('./check.js');
+    }
+  });
+
   it("does not start a check for the 'upgrade' command itself", async () => {
     const { maybeStartUpdateCheck, flushUpdateNotice } = await freshNotifier();
     const getLatest = vi.fn(async () => release('0.24.0'));
@@ -145,6 +186,58 @@ describe('notifier', () => {
 
     flushUpdateNotice();
     expect(output()).toBe('');
+  });
+
+  it('prints nothing when the local version is ahead of the latest release', async () => {
+    const { maybeStartUpdateCheck, flushUpdateNotice } = await freshNotifier();
+    const getLatest = vi.fn(async () => release('0.23.1'));
+    const { stream, output } = captureStream();
+
+    await maybeStartUpdateCheck('status', {
+      isTty: true,
+      env: {},
+      currentVersion: '0.24.0',
+      getLatest,
+      output: stream,
+    });
+
+    flushUpdateNotice();
+    expect(output()).toBe('');
+  });
+
+  it('prints nothing when the latest is a prerelease of the current version', async () => {
+    const { maybeStartUpdateCheck, flushUpdateNotice } = await freshNotifier();
+    const getLatest = vi.fn(async () => release('0.24.0-rc.1'));
+    const { stream, output } = captureStream();
+
+    await maybeStartUpdateCheck('status', {
+      isTty: true,
+      env: {},
+      currentVersion: '0.24.0',
+      getLatest,
+      output: stream,
+    });
+
+    flushUpdateNotice();
+    expect(output()).toBe('');
+  });
+
+  it('notifies when running a prerelease and the final release is out', async () => {
+    const { maybeStartUpdateCheck, flushUpdateNotice } = await freshNotifier();
+    const getLatest = vi.fn(async () => release('0.24.0'));
+    const { stream, output } = captureStream();
+
+    await maybeStartUpdateCheck('status', {
+      isTty: true,
+      env: {},
+      currentVersion: '0.24.0-beta.1',
+      getLatest,
+      output: stream,
+    });
+
+    flushUpdateNotice();
+    expect(output()).toContain('0.24.0');
+    expect(output()).toContain('search-hub upgrade');
   });
 
   it('prints nothing when the check returns null (network failure)', async () => {
@@ -250,5 +343,33 @@ describe('notifier', () => {
     const first = output();
     flushUpdateNotice();
     expect(output()).toBe(first);
+  });
+});
+
+describe('isNewerVersion', () => {
+  it.each([
+    ['0.24.0', '0.23.1', true],
+    ['0.23.1', '0.24.0', false],
+    ['0.23.1', '0.23.1', false],
+    ['1.0.0', '0.99.9', true],
+    ['0.24.1', '0.24.0', true],
+    // A release is newer than its own prerelease, not the other way around.
+    ['0.24.0', '0.24.0-beta.1', true],
+    ['0.24.0-beta.1', '0.24.0', false],
+    // Numeric prerelease identifiers compare numerically, not lexically.
+    ['0.24.0-beta.2', '0.24.0-beta.1', true],
+    ['0.24.0-beta.10', '0.24.0-beta.2', true],
+    ['0.24.0-rc.1', '0.24.0-beta.1', true],
+    // Tags may carry a leading v.
+    ['v0.24.0', '0.23.1', true],
+  ])('isNewerVersion(%s, %s) -> %s', async (candidate, current, expected) => {
+    const { isNewerVersion } = await import('./notifier.js');
+    expect(isNewerVersion(candidate, current)).toBe(expected);
+  });
+
+  it('falls back to plain inequality for non-semver strings', async () => {
+    const { isNewerVersion } = await import('./notifier.js');
+    expect(isNewerVersion('nightly-2', 'nightly-1')).toBe(true);
+    expect(isNewerVersion('nightly-1', 'nightly-1')).toBe(false);
   });
 });

--- a/src/upgrade/notifier.test.ts
+++ b/src/upgrade/notifier.test.ts
@@ -1,0 +1,254 @@
+import { PassThrough } from 'node:stream';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReleaseInfo } from './check.js';
+import type * as NotifierModule from './notifier.js';
+
+function captureStream(): { stream: NodeJS.WritableStream; output: () => string } {
+  const stream = new PassThrough();
+  let buf = '';
+  stream.on('data', (chunk) => {
+    buf += String(chunk);
+  });
+  return { stream, output: () => buf };
+}
+
+function release(latest: string): ReleaseInfo {
+  return {
+    checkedAt: '2026-07-12T12:00:00Z',
+    latest,
+    url: `https://github.com/ncukondo/search-hub/releases/tag/v${latest}`,
+  };
+}
+
+async function freshNotifier(): Promise<typeof NotifierModule> {
+  vi.resetModules();
+  return await import('./notifier.js');
+}
+
+describe('notifier', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('does not start a check when stdout is not a TTY', async () => {
+    const { maybeStartUpdateCheck, flushUpdateNotice } = await freshNotifier();
+    const getLatest = vi.fn(async () => release('0.24.0'));
+    const { stream, output } = captureStream();
+
+    await maybeStartUpdateCheck('status', {
+      isTty: false,
+      env: {},
+      currentVersion: '0.23.1',
+      getLatest,
+      output: stream,
+    });
+
+    expect(getLatest).not.toHaveBeenCalled();
+    flushUpdateNotice();
+    expect(output()).toBe('');
+  });
+
+  it('does not start a check when SEARCH_HUB_NO_UPDATE_CHECK=1', async () => {
+    const { maybeStartUpdateCheck, flushUpdateNotice } = await freshNotifier();
+    const getLatest = vi.fn(async () => release('0.24.0'));
+    const { stream, output } = captureStream();
+
+    await maybeStartUpdateCheck('status', {
+      isTty: true,
+      env: { SEARCH_HUB_NO_UPDATE_CHECK: '1' },
+      currentVersion: '0.23.1',
+      getLatest,
+      output: stream,
+    });
+
+    expect(getLatest).not.toHaveBeenCalled();
+    flushUpdateNotice();
+    expect(output()).toBe('');
+  });
+
+  it('does not start a check when noUpdateCheck=true (e.g. --no-update-check)', async () => {
+    const { maybeStartUpdateCheck, flushUpdateNotice } = await freshNotifier();
+    const getLatest = vi.fn(async () => release('0.24.0'));
+    const { stream, output } = captureStream();
+
+    await maybeStartUpdateCheck('status', {
+      isTty: true,
+      env: {},
+      currentVersion: '0.23.1',
+      getLatest,
+      output: stream,
+      noUpdateCheck: true,
+    });
+
+    expect(getLatest).not.toHaveBeenCalled();
+    flushUpdateNotice();
+    expect(output()).toBe('');
+  });
+
+  it("does not start a check for the 'upgrade' command itself", async () => {
+    const { maybeStartUpdateCheck, flushUpdateNotice } = await freshNotifier();
+    const getLatest = vi.fn(async () => release('0.24.0'));
+    const { stream, output } = captureStream();
+
+    await maybeStartUpdateCheck('upgrade', {
+      isTty: true,
+      env: {},
+      currentVersion: '0.23.1',
+      getLatest,
+      output: stream,
+    });
+
+    expect(getLatest).not.toHaveBeenCalled();
+    flushUpdateNotice();
+    expect(output()).toBe('');
+  });
+
+  it('prints an ASCII-only notice to the configured stream when a newer version is available', async () => {
+    const { maybeStartUpdateCheck, flushUpdateNotice } = await freshNotifier();
+    const getLatest = vi.fn(async () => release('0.24.0'));
+    const { stream, output } = captureStream();
+
+    await maybeStartUpdateCheck('status', {
+      isTty: true,
+      env: {},
+      currentVersion: '0.23.1',
+      getLatest,
+      output: stream,
+    });
+
+    expect(getLatest).toHaveBeenCalledTimes(1);
+    flushUpdateNotice();
+
+    const text = output();
+    expect(text).toContain('0.23.1');
+    expect(text).toContain('0.24.0');
+    expect(text).toContain('search-hub upgrade');
+    // The notice must use ASCII-only characters so it renders on legacy
+    // Windows terminals (cmd.exe / non-UTF-8 code pages).
+    expect(text).toMatch(/^[\x00-\x7f]*$/); // eslint-disable-line no-control-regex
+    expect(text).not.toContain('✨');
+    expect(text).not.toContain('→');
+  });
+
+  it('prints nothing when the running version equals the latest', async () => {
+    const { maybeStartUpdateCheck, flushUpdateNotice } = await freshNotifier();
+    const getLatest = vi.fn(async () => release('0.23.1'));
+    const { stream, output } = captureStream();
+
+    await maybeStartUpdateCheck('status', {
+      isTty: true,
+      env: {},
+      currentVersion: '0.23.1',
+      getLatest,
+      output: stream,
+    });
+
+    flushUpdateNotice();
+    expect(output()).toBe('');
+  });
+
+  it('prints nothing when the check returns null (network failure)', async () => {
+    const { maybeStartUpdateCheck, flushUpdateNotice } = await freshNotifier();
+    const getLatest = vi.fn(async () => null);
+    const { stream, output } = captureStream();
+
+    await maybeStartUpdateCheck('status', {
+      isTty: true,
+      env: {},
+      currentVersion: '0.23.1',
+      getLatest,
+      output: stream,
+    });
+
+    flushUpdateNotice();
+    expect(output()).toBe('');
+  });
+
+  it('returns synchronously without awaiting the async check', async () => {
+    const { maybeStartUpdateCheck, flushUpdateNotice } = await freshNotifier();
+    let resolveCheck: (v: ReleaseInfo) => void = () => {};
+    const pending = new Promise<ReleaseInfo>((r) => {
+      resolveCheck = r;
+    });
+    const getLatest = vi.fn(() => pending);
+    const { stream, output } = captureStream();
+
+    const before = Date.now();
+    const checkDone = maybeStartUpdateCheck('status', {
+      isTty: true,
+      env: {},
+      currentVersion: '0.23.1',
+      getLatest,
+      output: stream,
+    });
+    const after = Date.now();
+
+    expect(after - before).toBeLessThan(50);
+
+    // Check has not resolved yet, so flush should print nothing.
+    flushUpdateNotice();
+    expect(output()).toBe('');
+
+    resolveCheck(release('0.24.0'));
+    await checkDone;
+  });
+
+  it('does not throw when the check rejects', async () => {
+    const { maybeStartUpdateCheck, flushUpdateNotice } = await freshNotifier();
+    const getLatest = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const { stream, output } = captureStream();
+
+    await maybeStartUpdateCheck('status', {
+      isTty: true,
+      env: {},
+      currentVersion: '0.23.1',
+      getLatest,
+      output: stream,
+    });
+
+    expect(() => flushUpdateNotice()).not.toThrow();
+    expect(output()).toBe('');
+  });
+
+  it("registers the process 'exit' listener only once across repeated calls", async () => {
+    const { maybeStartUpdateCheck } = await freshNotifier();
+    const getLatest = vi.fn(async () => release('0.24.0'));
+    const { stream } = captureStream();
+
+    const before = process.listenerCount('exit');
+
+    for (let i = 0; i < 5; i++) {
+      await maybeStartUpdateCheck('status', {
+        isTty: true,
+        env: {},
+        currentVersion: '0.23.1',
+        getLatest,
+        output: stream,
+      });
+    }
+
+    const after = process.listenerCount('exit');
+    expect(after - before).toBe(1);
+  });
+
+  it('does not double-print when flush is called twice', async () => {
+    const { maybeStartUpdateCheck, flushUpdateNotice } = await freshNotifier();
+    const getLatest = vi.fn(async () => release('0.24.0'));
+    const { stream, output } = captureStream();
+
+    await maybeStartUpdateCheck('status', {
+      isTty: true,
+      env: {},
+      currentVersion: '0.23.1',
+      getLatest,
+      output: stream,
+    });
+
+    flushUpdateNotice();
+    const first = output();
+    flushUpdateNotice();
+    expect(output()).toBe(first);
+  });
+});

--- a/src/upgrade/notifier.ts
+++ b/src/upgrade/notifier.ts
@@ -17,6 +17,13 @@ import { type ReleaseInfo, getLatestVersion } from './check.js';
  */
 const SUPPRESSED_COMMANDS = new Set(['upgrade']);
 
+/**
+ * Abort the notifier's version check after this long. The check is fire-and
+ * -forget, but an in-flight fetch keeps the event loop alive — without a
+ * timeout, a hung connection would delay process exit for minutes.
+ */
+const CHECK_TIMEOUT_MS = 3000;
+
 export interface NotifierOptions {
   isTty?: boolean;
   env?: NodeJS.ProcessEnv;
@@ -25,6 +32,8 @@ export interface NotifierOptions {
   output?: NodeJS.WritableStream;
   /** When true, suppress the check (e.g. user passed `--no-update-check`). */
   noUpdateCheck?: boolean;
+  /** When true, suppress the check (global `--quiet`: only errors may print). */
+  quiet?: boolean;
 }
 
 interface NotifierState {
@@ -49,10 +58,12 @@ function isSuppressed(
   command: string,
   env: NodeJS.ProcessEnv,
   isTty: boolean,
-  noUpdateCheckFlag: boolean
+  noUpdateCheckFlag: boolean,
+  quiet: boolean
 ): boolean {
   if (!isTty) return true;
   if (noUpdateCheckFlag) return true;
+  if (quiet) return true;
   if (env['SEARCH_HUB_NO_UPDATE_CHECK'] === '1') return true;
   if (SUPPRESSED_COMMANDS.has(command)) return true;
   return false;
@@ -72,12 +83,14 @@ export function maybeStartUpdateCheck(
   const env = options.env ?? process.env;
   const isTty = options.isTty ?? process.stdout.isTTY === true;
   const noUpdateCheck = options.noUpdateCheck ?? false;
+  const quiet = options.quiet ?? false;
 
-  if (isSuppressed(command, env, isTty, noUpdateCheck)) return Promise.resolve();
+  if (isSuppressed(command, env, isTty, noUpdateCheck, quiet)) return Promise.resolve();
 
   const currentVersion = options.currentVersion ?? VERSION;
   const output = options.output ?? process.stderr;
-  const getLatest = options.getLatest ?? (() => getLatestVersion());
+  const getLatest =
+    options.getLatest ?? (() => getLatestVersion({ timeoutMs: CHECK_TIMEOUT_MS }));
 
   const localState: NotifierState = {
     result: null,
@@ -98,11 +111,79 @@ export function maybeStartUpdateCheck(
   );
 }
 
+interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+}
+
+const SEMVER_RE =
+  /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+function parseSemver(version: string): ParsedVersion | null {
+  const match = SEMVER_RE.exec(version);
+  if (!match) return null;
+  const [, major, minor, patch, prerelease] = match;
+  if (major === undefined || minor === undefined || patch === undefined) return null;
+  return {
+    major: Number(major),
+    minor: Number(minor),
+    patch: Number(patch),
+    prerelease: prerelease ? prerelease.split('.') : [],
+  };
+}
+
+/** Semver precedence for prerelease identifier lists (empty = full release). */
+function comparePrerelease(a: string[], b: string[]): number {
+  if (a.length === 0 && b.length === 0) return 0;
+  // A version without prerelease identifiers outranks one with them.
+  if (a.length === 0) return 1;
+  if (b.length === 0) return -1;
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const idA = a[i];
+    const idB = b[i];
+    // The longer identifier list wins once the shared prefix is equal.
+    if (idA === undefined) return -1;
+    if (idB === undefined) return 1;
+    const numA = /^\d+$/.test(idA) ? Number(idA) : null;
+    const numB = /^\d+$/.test(idB) ? Number(idB) : null;
+    if (numA !== null && numB !== null) {
+      if (numA !== numB) return numA < numB ? -1 : 1;
+    } else if (numA !== null) {
+      // Numeric identifiers rank below alphanumeric ones.
+      return -1;
+    } else if (numB !== null) {
+      return 1;
+    } else if (idA !== idB) {
+      return idA < idB ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+/**
+ * True when `candidate` is a strictly newer semver than `current`. Falls back
+ * to plain inequality when either side is not parseable as semver, so odd
+ * tags still produce a notice rather than being silently ignored.
+ */
+export function isNewerVersion(candidate: string, current: string): boolean {
+  const a = parseSemver(candidate);
+  const b = parseSemver(current);
+  if (!a || !b) return candidate !== current;
+  if (a.major !== b.major) return a.major > b.major;
+  if (a.minor !== b.minor) return a.minor > b.minor;
+  if (a.patch !== b.patch) return a.patch > b.patch;
+  return comparePrerelease(a.prerelease, b.prerelease) > 0;
+}
+
 export function flushUpdateNotice(): void {
   if (!state || state.printed) return;
   const { result, currentVersion, output } = state;
   if (!result) return;
-  if (result.latest === currentVersion) return;
+  // Only a strictly newer release warrants a notice; a local version that is
+  // ahead of the latest release (e.g. bumped but unreleased) must stay quiet.
+  if (!isNewerVersion(result.latest, currentVersion)) return;
   state.printed = true;
   output.write(
     `\n>>> New version available: ${currentVersion} -> ${result.latest}\n    Run: search-hub upgrade\n`

--- a/src/upgrade/notifier.ts
+++ b/src/upgrade/notifier.ts
@@ -1,0 +1,110 @@
+/**
+ * Update-check notifier.
+ *
+ * Kicks off an async version check at CLI entry, then prints a one-line
+ * ASCII notice to stderr after the user's command completes — but only if
+ * the check has already resolved by then. The user's command is never
+ * delayed, and machine-readable stdout (JSON/YAML output) is never touched:
+ * the notice goes to stderr and only when stdout is a TTY.
+ */
+import { VERSION } from '../version.js';
+import { type ReleaseInfo, getLatestVersion } from './check.js';
+
+/**
+ * Commands that never trigger the check. search-hub has no long-running or
+ * completion commands; only `upgrade` itself is suppressed (redundant there).
+ * Machine-facing output paths are covered by the non-TTY suppression rule.
+ */
+const SUPPRESSED_COMMANDS = new Set(['upgrade']);
+
+export interface NotifierOptions {
+  isTty?: boolean;
+  env?: NodeJS.ProcessEnv;
+  currentVersion?: string;
+  getLatest?: () => Promise<ReleaseInfo | null>;
+  output?: NodeJS.WritableStream;
+  /** When true, suppress the check (e.g. user passed `--no-update-check`). */
+  noUpdateCheck?: boolean;
+}
+
+interface NotifierState {
+  result: ReleaseInfo | null;
+  currentVersion: string;
+  output: NodeJS.WritableStream;
+  printed: boolean;
+}
+
+let state: NotifierState | null = null;
+let exitListenerRegistered = false;
+
+function ensureExitListener(): void {
+  if (exitListenerRegistered) return;
+  exitListenerRegistered = true;
+  process.on('exit', () => {
+    flushUpdateNotice();
+  });
+}
+
+function isSuppressed(
+  command: string,
+  env: NodeJS.ProcessEnv,
+  isTty: boolean,
+  noUpdateCheckFlag: boolean
+): boolean {
+  if (!isTty) return true;
+  if (noUpdateCheckFlag) return true;
+  if (env['SEARCH_HUB_NO_UPDATE_CHECK'] === '1') return true;
+  if (SUPPRESSED_COMMANDS.has(command)) return true;
+  return false;
+}
+
+/**
+ * Kicks off the async update check. Returns a promise that resolves once the
+ * check is done (or immediately, if the check was suppressed). Production
+ * callers typically ignore the returned promise; tests can await it.
+ */
+export function maybeStartUpdateCheck(
+  command: string,
+  options: NotifierOptions = {}
+): Promise<void> {
+  state = null;
+
+  const env = options.env ?? process.env;
+  const isTty = options.isTty ?? process.stdout.isTTY === true;
+  const noUpdateCheck = options.noUpdateCheck ?? false;
+
+  if (isSuppressed(command, env, isTty, noUpdateCheck)) return Promise.resolve();
+
+  const currentVersion = options.currentVersion ?? VERSION;
+  const output = options.output ?? process.stderr;
+  const getLatest = options.getLatest ?? (() => getLatestVersion());
+
+  const localState: NotifierState = {
+    result: null,
+    currentVersion,
+    output,
+    printed: false,
+  };
+  state = localState;
+  ensureExitListener();
+
+  return getLatest().then(
+    (releaseInfo) => {
+      localState.result = releaseInfo;
+    },
+    () => {
+      // Errors are silent; nothing will be printed.
+    }
+  );
+}
+
+export function flushUpdateNotice(): void {
+  if (!state || state.printed) return;
+  const { result, currentVersion, output } = state;
+  if (!result) return;
+  if (result.latest === currentVersion) return;
+  state.printed = true;
+  output.write(
+    `\n>>> New version available: ${currentVersion} -> ${result.latest}\n    Run: search-hub upgrade\n`
+  );
+}

--- a/src/upgrade/upgrade.e2e.test.ts
+++ b/src/upgrade/upgrade.e2e.test.ts
@@ -1,0 +1,184 @@
+/**
+ * E2E tests for the self-upgrade feature.
+ *
+ * Covers the full `upgrade --check` flow against a mocked GitHub API,
+ * the binary replace flow with a temp dir standing in for the install dir,
+ * the notifier end-to-end with a fake cache file, and the compiled CLI via
+ * subprocess (dev-install guidance, no notice on piped output).
+ * No real network calls are made.
+ */
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execCli } from '../cli/e2e-helpers.js';
+import { runUpgrade } from '../cli/commands/upgrade.js';
+import { upgradeBinary } from './apply-binary.js';
+import { getLatestVersion } from './check.js';
+
+function captureStream(): { stream: NodeJS.WritableStream; output: () => string } {
+  const stream = new PassThrough();
+  let buf = '';
+  stream.on('data', (chunk) => {
+    buf += String(chunk);
+  });
+  return { stream, output: () => buf };
+}
+
+function makeGitHubApiFetch(tag: string): typeof globalThis.fetch {
+  return vi.fn(
+    async () =>
+      new Response(
+        JSON.stringify({
+          tag_name: tag,
+          html_url: `https://github.com/ncukondo/search-hub/releases/tag/${tag}`,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+  ) as unknown as typeof globalThis.fetch;
+}
+
+describe('upgrade e2e', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `upgrade-e2e-${randomUUID()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('runs the full `upgrade --check` flow against a mocked GitHub API', async () => {
+    const cachePath = join(testDir, 'update-check.json');
+    const apiFetch = makeGitHubApiFetch('v9.9.9');
+    const destPath = join(testDir, 'search-hub');
+    writeFileSync(destPath, 'current binary\n', { mode: 0o755 });
+
+    const { stream: stdout, output } = captureStream();
+    const { stream: stderr } = captureStream();
+
+    // Real command wiring -> real binary strategy -> real check module; only
+    // the HTTP layer is mocked and the cache redirected to a temp file.
+    const result = await runUpgrade(
+      { check: true },
+      {
+        installMethod: 'binary',
+        argv1: destPath,
+        currentVersion: '0.23.1',
+        upgradeBinaryFn: (options) =>
+          upgradeBinary({
+            ...options,
+            platform: 'linux',
+            arch: 'x64',
+            getLatest: () => getLatestVersion({ cachePath, fetch: apiFetch }),
+          }),
+        stdout,
+        stderr,
+      }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.result?.status).toBe('guidance');
+    expect(result.result?.toVersion).toBe('9.9.9');
+    expect(output()).toContain(
+      'https://github.com/ncukondo/search-hub/releases/download/v9.9.9/search-hub-linux-x64'
+    );
+    // The check wrote the cache; a second run must not hit the network again.
+    expect(existsSync(cachePath)).toBe(true);
+    await getLatestVersion({ cachePath, fetch: apiFetch });
+    expect(apiFetch).toHaveBeenCalledTimes(1);
+    // --check must not touch the binary.
+    expect(readFileSync(destPath, 'utf-8')).toBe('current binary\n');
+  });
+
+  it('replaces the binary in a temp install dir (download -> verify -> atomic replace)', async () => {
+    const installDir = join(testDir, 'install');
+    mkdirSync(installDir, { recursive: true });
+    const destPath = join(installDir, 'search-hub');
+    writeFileSync(destPath, '#!/bin/sh\necho "search-hub 0.23.1"\n', { mode: 0o755 });
+
+    // The "downloaded asset" is a real executable script so the default
+    // verifier (`{tmp} --version`) genuinely runs it.
+    const newBinary = '#!/bin/sh\necho "search-hub 9.9.9"\n';
+    const assetFetch = vi.fn(
+      async () =>
+        new Response(new TextEncoder().encode(newBinary), {
+          status: 200,
+          headers: { 'content-type': 'application/octet-stream' },
+        })
+    ) as unknown as typeof globalThis.fetch;
+
+    const result = await upgradeBinary({
+      destPath,
+      currentVersion: '0.23.1',
+      version: 'v9.9.9',
+      platform: 'linux',
+      arch: 'x64',
+      fetch: assetFetch,
+    });
+
+    expect(result.status).toBe('success');
+    expect(result.toVersion).toBe('9.9.9');
+    expect(result.message).toBe('search-hub 9.9.9');
+    expect(readFileSync(destPath, 'utf-8')).toBe(newBinary);
+    // No temp files left behind.
+    expect(existsSync(`${destPath}.tmp.${process.pid}`)).toBe(false);
+  });
+
+  it('notifier end-to-end: fresh fake cache file produces a notice without network', async () => {
+    const cachePath = join(testDir, 'update-check.json');
+    writeFileSync(
+      cachePath,
+      JSON.stringify({
+        checkedAt: new Date().toISOString(),
+        latest: '9.9.9',
+        url: 'https://github.com/ncukondo/search-hub/releases/tag/v9.9.9',
+      })
+    );
+    const networkFetch = vi.fn(async () => {
+      throw new Error('network must not be hit when cache is fresh');
+    }) as unknown as typeof globalThis.fetch;
+
+    vi.resetModules();
+    const { maybeStartUpdateCheck, flushUpdateNotice } = await import('./notifier.js');
+    const { stream, output } = captureStream();
+
+    await maybeStartUpdateCheck('status', {
+      isTty: true,
+      env: {},
+      currentVersion: '0.23.1',
+      getLatest: () => getLatestVersion({ cachePath, fetch: networkFetch }),
+      output: stream,
+    });
+    flushUpdateNotice();
+
+    expect(networkFetch).not.toHaveBeenCalled();
+    const text = output();
+    expect(text).toContain('>>> New version available: 0.23.1 -> 9.9.9');
+    expect(text).toContain('Run: search-hub upgrade');
+  });
+
+  it('subprocess: `upgrade --check` from the repo checkout prints dev guidance and exits 2', async () => {
+    const result = await execCli(['upgrade', '--check'], {
+      env: { SEARCH_HUB_NO_UPDATE_CHECK: '1' },
+    });
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toMatch(/dev install/i);
+    expect(result.stderr).toContain('search-hub upgrade');
+  });
+
+  it('subprocess: piped output never contains the update notice', async () => {
+    const result = await execCli(['--help']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('>>>');
+    expect(result.stderr).not.toContain('>>>');
+    // The upgrade command is registered and shows up in help.
+    expect(result.stdout).toContain('upgrade');
+  });
+});


### PR DESCRIPTION
## Summary

Ports the self-upgrade feature from reference-manager to search-hub
(task `spec/tasks/20260712-02-self-upgrade.md`):

- **`search-hub upgrade`** upgrades single-binary and npm-global installs;
  dev/npx installs get guidance only (exit code 2).
- Options: `--check`, `--version <tag>`, `-y/--yes`, `--install-dir <path>`.
- **Update notification**: after any normal command finishes in a TTY, a
  one-line ASCII notice is printed to stderr when a newer release exists
  (async check, 24h cache at `{data}/update-check.json`, silent on network
  failure, rate-limit fallback to cache).
- Suppression: non-TTY stdout, `SEARCH_HUB_NO_UPDATE_CHECK=1`,
  `--no-update-check`, and the `upgrade` command itself.

## Implementation notes

- `src/upgrade/{detect,check,notifier,apply-binary,apply-npm}.ts` ported with
  search-hub constants (repo `ncukondo/search-hub`, assets
  `search-hub-{os}-{arch}[.exe]`, package `@ncukondo/search-hub`).
- **Bun-compiled binary support**: in a `bun build --compile` binary,
  `process.argv[1]` is a virtual bunfs path (`/$bunfs/root/...`);
  `resolveInvocationPath()` falls back to `process.execPath` so install-method
  detection and dest-path resolution work in the compiled binary.
- `upgrade --version <tag>` is rewritten to `--version=<tag>` pre-parse so the
  root `--version` flag doesn't swallow it.
- `src/version.ts` remains the single version source.
- `spec/cli/commands.md` documents the command, exit codes, notification
  behavior, and suppression rules.

## Testing

- 67 new unit tests (detect/check/apply-binary/apply-npm/notifier/command/argv)
  — all network and child-process calls mocked.
- `src/upgrade/upgrade.e2e.test.ts`: full `upgrade --check` flow against a
  mocked GitHub API, real download→verify→atomic-replace into a temp install
  dir, notifier end-to-end with a fake cache, and subprocess tests (dev
  guidance exit 2, no notice in piped output).
- `npm run test:all`: unit and e2e pass (pre-existing flakes: register.e2e
  timeouts under full parallel load pass in isolation; one live-API ERIC
  failure in the `api` project is unrelated to this change).
- `npm run lint` (0 errors, new files warning-free) and `npm run typecheck` pass.
- Manual: built the Bun binary via `scripts/build-binary.sh`; inside the
  worktree it prints dev guidance (exit 2), and copied to a `.local/bin` dir
  with a fresh cache it reports the update with the correct asset URL (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UM1E8idryL2ASK5ComxbsF