### PR TITLE
feat(rate-limiter): add ±25% jitter to exponential backoff (#4)

### DIFF
--- a/spec/tasks/20260713-01-rate-limiter-backoff-jitter.md
+++ b/spec/tasks/20260713-01-rate-limiter-backoff-jitter.md
@@ -64,10 +64,13 @@ Each step follows the TDD cycle: Red → Green → Refactor.
 
 ### Final Step: E2E Integration Tests (MANDATORY)
 
-- [ ] Verify existing rate limiter tests still pass unchanged (backward compatibility)
-- [ ] Statistical test with real `Math.random` (no stub): over many calls, sleep durations vary within [0.75, 1.25] × backoff
-- [ ] Run full test suite: `npm test`
-- [ ] Acceptance: all tests pass, default behavior (no `random` option) uses jitter
+- [x] Verify existing rate limiter tests still pass unchanged (backward compatibility)
+      (three exact-timing tests stub `random: () => 0.5` — see Step 2 note)
+- [x] Statistical test with real `Math.random` (no stub): over many calls, sleep durations vary within [0.75, 1.25] × backoff
+- [x] Run full test suite: `npm test`
+      (unit + e2e pass; api-project failures are environmental `fetch failed`
+      network errors, unrelated to this change)
+- [x] Acceptance: all tests pass, default behavior (no `random` option) uses jitter
 
 ## Notes
 

--- a/spec/tasks/20260713-01-rate-limiter-backoff-jitter.md
+++ b/spec/tasks/20260713-01-rate-limiter-backoff-jitter.md
@@ -37,13 +37,13 @@ Notes:
 
 Each step follows the TDD cycle: Red → Green → Refactor.
 
-- [ ] Step 1: Injectable random source
-  - [ ] Write test: `RateLimiterOptions.random` is used by `handleRateLimit` (pass a stub returning fixed values)
-  - [ ] Verify test fails (Red)
-  - [ ] Add `random?: () => number` option, default `Math.random`
-  - [ ] Verify test passes (Green)
-  - [ ] Run `npm run lint && npm run typecheck`
-  - [ ] Acceptance: stubbed random source is observed by handleRateLimit
+- [x] Step 1: Injectable random source
+  - [x] Write test: `RateLimiterOptions.random` is used by `handleRateLimit` (pass a stub returning fixed values)
+  - [x] Verify test fails (Red)
+  - [x] Add `random?: () => number` option, default `Math.random`
+  - [x] Verify test passes (Green)
+  - [x] Run `npm run lint && npm run typecheck`
+  - [x] Acceptance: stubbed random source is observed by handleRateLimit
 
 - [ ] Step 2: Jitter applied to backoff sleep
   - [ ] Write tests (use fake timers + stubbed random):

--- a/spec/tasks/20260713-01-rate-limiter-backoff-jitter.md
+++ b/spec/tasks/20260713-01-rate-limiter-backoff-jitter.md
@@ -45,19 +45,22 @@ Each step follows the TDD cycle: Red → Green → Refactor.
   - [x] Run `npm run lint && npm run typecheck`
   - [x] Acceptance: stubbed random source is observed by handleRateLimit
 
-- [ ] Step 2: Jitter applied to backoff sleep
-  - [ ] Write tests (use fake timers + stubbed random):
+- [x] Step 2: Jitter applied to backoff sleep
+  - [x] Write tests (use fake timers + stubbed random):
     - `random() = 0.5` → jitter factor 1.0 → sleeps exactly `currentBackoff`
     - `random() = 0` → factor 0.75 → sleeps `0.75 * currentBackoff`
     - `random() = 1` (or close) → factor ~1.25 → sleeps `~1.25 * currentBackoff`
     - Jittered delay never exceeds `maxBackoff`
     - `currentBackoff` still doubles deterministically after each call (unaffected by jitter)
     - `handleRateLimit(retryAfter)` sleeps exactly `retryAfter` (no jitter)
-  - [ ] Verify tests fail (Red)
-  - [ ] Implement jitter in `handleRateLimit`
-  - [ ] Verify tests pass (Green)
-  - [ ] Run `npm run lint && npm run typecheck`
-  - [ ] Acceptance: all above behaviors verified
+  - [x] Verify tests fail (Red)
+  - [x] Implement jitter in `handleRateLimit`
+  - [x] Verify tests pass (Green)
+  - [x] Run `npm run lint && npm run typecheck`
+  - [x] Acceptance: all above behaviors verified
+  - Note: three pre-existing backoff tests advance timers by the exact
+    nominal backoff; they now stub `random: () => 0.5` (factor 1.0) so
+    their exponential-growth assertions remain exact under default jitter.
 
 ### Final Step: E2E Integration Tests (MANDATORY)
 

--- a/src/providers/base/rate-limiter.test.ts
+++ b/src/providers/base/rate-limiter.test.ts
@@ -229,6 +229,7 @@ describe('RateLimiter', () => {
       const limiter = new RateLimiter({
         initialBackoff: 100,
         maxBackoff: 10000,
+        random: () => 0.5, // jitter factor 1.0 for exact timing
       });
 
       // First call should wait initialBackoff
@@ -251,6 +252,7 @@ describe('RateLimiter', () => {
       const limiter = new RateLimiter({
         initialBackoff: 1000,
         maxBackoff: 2000,
+        random: () => 0.5, // jitter factor 1.0 for exact timing
       });
 
       // First call
@@ -273,6 +275,7 @@ describe('RateLimiter', () => {
       const limiter = new RateLimiter({
         initialBackoff: 100,
         maxBackoff: 10000,
+        random: () => 0.5, // jitter factor 1.0 for exact timing
       });
 
       // Build up backoff
@@ -318,6 +321,86 @@ describe('RateLimiter', () => {
       const promise = limiter.handleRateLimit(1000);
       vi.advanceTimersByTime(1000);
       await promise;
+    });
+  });
+
+  describe('backoff jitter', () => {
+    /** Assert that the promise resolves after exactly `ms` (not before). */
+    async function expectSleepsFor(promise: Promise<void>, ms: number): Promise<void> {
+      let resolved = false;
+      void promise.then(() => {
+        resolved = true;
+      });
+      await vi.advanceTimersByTimeAsync(ms - 1);
+      expect(resolved).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(resolved).toBe(true);
+    }
+
+    it('sleeps exactly currentBackoff when random() = 0.5 (factor 1.0)', async () => {
+      const limiter = new RateLimiter({
+        initialBackoff: 100,
+        maxBackoff: 10000,
+        random: () => 0.5,
+      });
+
+      await expectSleepsFor(limiter.handleRateLimit(), 100);
+    });
+
+    it('sleeps 0.75 * currentBackoff when random() = 0', async () => {
+      const limiter = new RateLimiter({
+        initialBackoff: 100,
+        maxBackoff: 10000,
+        random: () => 0,
+      });
+
+      await expectSleepsFor(limiter.handleRateLimit(), 75);
+    });
+
+    it('sleeps 1.25 * currentBackoff when random() = 1', async () => {
+      const limiter = new RateLimiter({
+        initialBackoff: 100,
+        maxBackoff: 10000,
+        random: () => 1,
+      });
+
+      await expectSleepsFor(limiter.handleRateLimit(), 125);
+    });
+
+    it('jittered delay never exceeds maxBackoff', async () => {
+      const limiter = new RateLimiter({
+        initialBackoff: 100,
+        maxBackoff: 110,
+        random: () => 1,
+      });
+
+      // 100 * 1.25 = 125, capped at maxBackoff 110
+      await expectSleepsFor(limiter.handleRateLimit(), 110);
+    });
+
+    it('currentBackoff still doubles deterministically regardless of jitter', async () => {
+      const limiter = new RateLimiter({
+        initialBackoff: 100,
+        maxBackoff: 10000,
+        random: () => 0,
+      });
+
+      // Growth is 100 -> 200 -> 400; sleep is always 0.75x of the current value
+      await expectSleepsFor(limiter.handleRateLimit(), 75);
+      await expectSleepsFor(limiter.handleRateLimit(), 150);
+      await expectSleepsFor(limiter.handleRateLimit(), 300);
+    });
+
+    it('does not apply jitter to the retryAfter path', async () => {
+      const random = vi.fn().mockReturnValue(0);
+      const limiter = new RateLimiter({
+        initialBackoff: 100,
+        maxBackoff: 10000,
+        random,
+      });
+
+      await expectSleepsFor(limiter.handleRateLimit(1000), 1000);
+      expect(random).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/providers/base/rate-limiter.test.ts
+++ b/src/providers/base/rate-limiter.test.ts
@@ -293,6 +293,21 @@ describe('RateLimiter', () => {
       await p3;
     });
 
+    it('uses the injected random source for backoff', async () => {
+      const random = vi.fn().mockReturnValue(0.5);
+      const limiter = new RateLimiter({
+        initialBackoff: 100,
+        maxBackoff: 10000,
+        random,
+      });
+
+      const promise = limiter.handleRateLimit();
+      vi.advanceTimersByTime(100);
+      await promise;
+
+      expect(random).toHaveBeenCalled();
+    });
+
     it('respects Retry-After even when backoff is higher', async () => {
       const limiter = new RateLimiter({
         initialBackoff: 5000,

--- a/src/providers/base/rate-limiter.test.ts
+++ b/src/providers/base/rate-limiter.test.ts
@@ -391,6 +391,33 @@ describe('RateLimiter', () => {
       await expectSleepsFor(limiter.handleRateLimit(), 300);
     });
 
+    it('default Math.random produces varying delays within [0.75, 1.25) * backoff', async () => {
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+      const delays: number[] = [];
+
+      for (let i = 0; i < 100; i++) {
+        // No random option: default Math.random is used
+        const limiter = new RateLimiter({ initialBackoff: 1000, maxBackoff: 60000 });
+        const promise = limiter.handleRateLimit();
+
+        const lastCall = setTimeoutSpy.mock.calls.at(-1);
+        delays.push(Number(lastCall?.[1]));
+
+        await vi.advanceTimersByTimeAsync(1250);
+        await promise;
+      }
+
+      for (const delay of delays) {
+        expect(delay).toBeGreaterThanOrEqual(750);
+        expect(delay).toBeLessThan(1250);
+      }
+
+      // Sanity check that jitter actually varies the delays
+      expect(new Set(delays).size).toBeGreaterThan(1);
+
+      setTimeoutSpy.mockRestore();
+    });
+
     it('does not apply jitter to the retryAfter path', async () => {
       const random = vi.fn().mockReturnValue(0);
       const limiter = new RateLimiter({

--- a/src/providers/base/rate-limiter.ts
+++ b/src/providers/base/rate-limiter.ts
@@ -121,8 +121,9 @@ export class RateLimiter {
 
   /**
    * Handle a rate limit response (429) by waiting.
-   * If retryAfter is provided, waits that long.
-   * Otherwise, uses exponential backoff.
+   * If retryAfter is provided, waits exactly that long (no jitter).
+   * Otherwise, uses exponential backoff with random jitter (±25%)
+   * to avoid thundering-herd retries across concurrent clients.
    * @param retryAfter Optional time to wait in milliseconds (from Retry-After header)
    */
   async handleRateLimit(retryAfter?: number): Promise<void> {
@@ -131,11 +132,12 @@ export class RateLimiter {
       return;
     }
 
-    // Use exponential backoff
-    this.random();
-    await this.sleep(this.currentBackoff);
+    // Exponential backoff with jitter factor in [0.75, 1.25)
+    const jitter = 1 + (this.random() - 0.5) * 0.5;
+    const delay = Math.min(this.currentBackoff * jitter, this.maxBackoff);
+    await this.sleep(delay);
 
-    // Increase backoff for next time (exponential with cap)
+    // Backoff growth stays deterministic (exponential with cap)
     this.currentBackoff = Math.min(this.currentBackoff * 2, this.maxBackoff);
   }
 

--- a/src/providers/base/rate-limiter.ts
+++ b/src/providers/base/rate-limiter.ts
@@ -11,6 +11,8 @@ export interface RateLimiterOptions {
   initialBackoff?: number;
   /** Maximum backoff time in ms */
   maxBackoff?: number;
+  /** Random source for backoff jitter, in [0, 1). Defaults to Math.random */
+  random?: () => number;
 }
 
 const DEFAULT_OPTIONS: Required<RateLimiterOptions> = {
@@ -18,6 +20,7 @@ const DEFAULT_OPTIONS: Required<RateLimiterOptions> = {
   burstSize: 3,
   initialBackoff: 1000,
   maxBackoff: 60000,
+  random: Math.random,
 };
 
 /**
@@ -35,12 +38,14 @@ export class RateLimiter {
   private readonly initialBackoff: number;
   private readonly maxBackoff: number;
   private currentBackoff: number;
+  private readonly random: () => number;
 
   constructor(options: RateLimiterOptions = {}) {
     this.tokensPerSecond = options.tokensPerSecond ?? DEFAULT_OPTIONS.tokensPerSecond;
     this.burstSize = options.burstSize ?? DEFAULT_OPTIONS.burstSize;
     this.initialBackoff = options.initialBackoff ?? DEFAULT_OPTIONS.initialBackoff;
     this.maxBackoff = options.maxBackoff ?? DEFAULT_OPTIONS.maxBackoff;
+    this.random = options.random ?? DEFAULT_OPTIONS.random;
     this.tokens = this.burstSize;
     this.lastRefill = Date.now();
     this.currentBackoff = this.initialBackoff;
@@ -127,6 +132,7 @@ export class RateLimiter {
     }
 
     // Use exponential backoff
+    this.random();
     await this.sleep(this.currentBackoff);
 
     // Increase backoff for next time (exponential with cap)


### PR DESCRIPTION
## Summary

Adds random jitter (±25%) to the exponential backoff sleep in `RateLimiter.handleRateLimit()` to prevent the thundering-herd problem when multiple clients hit a rate limit simultaneously.

Resolves #4. Task file: `spec/tasks/20260713-01-rate-limiter-backoff-jitter.md`.

## Changes

- **`RateLimiterOptions.random`** — new injectable random source (`() => number`, defaults to `Math.random`) so jitter behavior is deterministic in tests
- **`handleRateLimit()`** — the backoff sleep is now `min(currentBackoff * jitter, maxBackoff)` with jitter factor in `[0.75, 1.25)`
- Backoff **growth** stays deterministic (×2, capped at `maxBackoff`); jitter applies only to the actual sleep duration
- The `retryAfter` path (explicit Retry-After header) is unchanged and gets **no** jitter

## Tests

- Injectable random source is observed by `handleRateLimit`
- Jitter factor boundaries: `random()=0.5` → exactly `currentBackoff`, `random()=0` → 0.75×, `random()=1` → 1.25×
- Jittered delay is capped at `maxBackoff`
- `currentBackoff` still doubles deterministically regardless of jitter
- `retryAfter` sleeps exactly as told, random source never consulted
- Statistical test with real `Math.random`: 100 delays all within `[0.75, 1.25) ×` backoff and actually varying
- Three pre-existing exact-timing backoff tests now stub `random: () => 0.5` (factor 1.0) so their exponential-growth assertions remain exact under default jitter

## Verification

- `npm run test:ci` (unit + e2e): pass — two unrelated flaky tests failed under full parallel load but pass in isolation
- api-project failures are environmental (`fetch failed` reaching NLM/ERIC APIs from this environment), unrelated to this change
- `npm run lint` / `npm run typecheck`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnWbdMbWMdUkGzF6U2ZHWt